### PR TITLE
fix: failing workflow to upload GraphQL Schema artifact upon releases

### DIFF
--- a/.github/workflows/upload-schema-artifact.yml
+++ b/.github/workflows/upload-schema-artifact.yml
@@ -12,6 +12,9 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v2
 
+      - name: Install dependencies
+        run: composer install
+
       - name: Copy environment files
         run: |
           cp .env.dist .env
@@ -28,7 +31,7 @@ jobs:
             --build-arg WP_VERSION=6.1 \
             --build-arg PHP_VERSION=8.1 \
             --build-arg DOCKER_REGISTRY=ghcr.io/wp-graphql/
-          docker-compose start app
+          docker-compose run app
 
       - name: Install WP CLI for ACF
         run: |


### PR DESCRIPTION
What does this implement/fix? Explain your changes.
---------------------------------------------------
- Change `docker-compose start app` to `docker-compose run app`


What currently open issues does this close or contribute?
------------------------------------------
closes #32 


Any other comments?
-------------------
This is hard to say for sure if it works without publishing a release. Running the commands locally appear to resolve the issue, but hard to fully reproduce the Github workflow environment.
