### PR TITLE
fix: graphql field names being set incorrectly

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -2216,16 +2216,16 @@
         },
         {
             "name": "nesbot/carbon",
-            "version": "2.67.0",
+            "version": "2.68.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/briannesbitt/Carbon.git",
-                "reference": "c1001b3bc75039b07f38a79db5237c4c529e04c8"
+                "reference": "4f991ed2a403c85efbc4f23eb4030063fdbe01da"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/briannesbitt/Carbon/zipball/c1001b3bc75039b07f38a79db5237c4c529e04c8",
-                "reference": "c1001b3bc75039b07f38a79db5237c4c529e04c8",
+                "url": "https://api.github.com/repos/briannesbitt/Carbon/zipball/4f991ed2a403c85efbc4f23eb4030063fdbe01da",
+                "reference": "4f991ed2a403c85efbc4f23eb4030063fdbe01da",
                 "shasum": ""
             },
             "require": {
@@ -2314,7 +2314,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2023-05-25T22:09:47+00:00"
+            "time": "2023-06-20T18:29:04+00:00"
         },
         {
             "name": "nikic/php-parser",
@@ -2814,16 +2814,16 @@
         },
         {
             "name": "phpstan/phpstan",
-            "version": "1.10.21",
+            "version": "1.10.25",
             "source": {
                 "type": "git",
                 "url": "https://github.com/phpstan/phpstan.git",
-                "reference": "b2a30186be2e4d97dce754ae4e65eb0ec2f04eb5"
+                "reference": "578f4e70d117f9a90699324c555922800ac38d8c"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpstan/phpstan/zipball/b2a30186be2e4d97dce754ae4e65eb0ec2f04eb5",
-                "reference": "b2a30186be2e4d97dce754ae4e65eb0ec2f04eb5",
+                "url": "https://api.github.com/repos/phpstan/phpstan/zipball/578f4e70d117f9a90699324c555922800ac38d8c",
+                "reference": "578f4e70d117f9a90699324c555922800ac38d8c",
                 "shasum": ""
             },
             "require": {
@@ -2872,7 +2872,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2023-06-21T20:07:58+00:00"
+            "time": "2023-07-06T12:11:37+00:00"
         },
         {
             "name": "phpunit/php-code-coverage",
@@ -7401,16 +7401,16 @@
         },
         {
             "name": "wp-graphql/wp-graphql",
-            "version": "v1.14.5",
+            "version": "v1.14.6",
             "source": {
                 "type": "git",
                 "url": "https://github.com/wp-graphql/wp-graphql.git",
-                "reference": "c83a40bcbc9a00b4c44790a84d967766ce2b5d90"
+                "reference": "5cefe7ca0823618432d27a00bca9fd762d09e5d9"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/wp-graphql/wp-graphql/zipball/c83a40bcbc9a00b4c44790a84d967766ce2b5d90",
-                "reference": "c83a40bcbc9a00b4c44790a84d967766ce2b5d90",
+                "url": "https://api.github.com/repos/wp-graphql/wp-graphql/zipball/5cefe7ca0823618432d27a00bca9fd762d09e5d9",
+                "reference": "5cefe7ca0823618432d27a00bca9fd762d09e5d9",
                 "shasum": ""
             },
             "require": {
@@ -7432,7 +7432,7 @@
                 "lucatume/wp-browser": "^3.1.6",
                 "phpcompatibility/phpcompatibility-wp": "^2.1",
                 "phpstan/extension-installer": "^1.1",
-                "phpstan/phpstan": "~1.10.11",
+                "phpstan/phpstan": "~1.10.18",
                 "phpunit/phpunit": "^9.5",
                 "simpod/php-coveralls-mirror": "^3.0",
                 "slevomat/coding-standard": "^8.9",
@@ -7475,9 +7475,9 @@
             "description": "GraphQL API for WordPress",
             "support": {
                 "issues": "https://github.com/wp-graphql/wp-graphql/issues",
-                "source": "https://github.com/wp-graphql/wp-graphql/tree/v1.14.5"
+                "source": "https://github.com/wp-graphql/wp-graphql/tree/v1.14.6"
             },
-            "time": "2023-06-26T19:30:24+00:00"
+            "time": "2023-06-30T18:20:43+00:00"
         },
         {
             "name": "wp-graphql/wp-graphql-testcase",

--- a/src/AcfGraphQLFieldType.php
+++ b/src/AcfGraphQLFieldType.php
@@ -134,30 +134,16 @@ class AcfGraphQLFieldType {
 			],
 		];
 
-		$graphql_field_name = '';
-
-		// If there's a graphql_field_name value, use it, allowing underscores
-		if ( ! empty( $field['graphql_field_name'] ) ) {
-			$graphql_field_name = \WPGraphQL\Utils\Utils::format_field_name( $field['graphql_field_name'], true );
-
-			// Else, use the field's name, if it's not "new_field" and format it without underscores
-		} elseif ( ! empty( $field['name'] ) && 'new_field' !== $field['name'] ) {
-			$graphql_field_name = \WPGraphQL\Utils\Utils::format_field_name( $field['name'], false );
-		}
-
-
 		$default_admin_settings['graphql_field_name'] = [
 			'label'         => __( 'GraphQL Field Name', 'wp-graphql-acf' ),
 			'instructions'  => __( 'The name of the field in the GraphQL Schema. Should only contain numbers and letters. Must start with a letter. Recommended format is "snakeCase".', 'wp-graphql-acf' ),
 			'name'          => 'graphql_field_name',
 			'type'          => 'text',
 			'ui'            => true,
-			'required'      => true,
+			'required'      => false,
 			// we don't allow underscores if the value is auto formatted
 			'placeholder'   => __( 'newFieldName', 'wp-graphql-acf' ),
 			'default_value' => '',
-			// allow underscores if the user enters the value with underscores
-			'value'         => $graphql_field_name,
 			'conditions'    => [
 				'field'    => 'show_in_graphql',
 				'operator' => '==',

--- a/src/assets/admin/js/main.js
+++ b/src/assets/admin/js/main.js
@@ -7,6 +7,7 @@ $j(document).ready(function () {
 	var graphqlFieldSettings = new acf.Model({
 		actions: {
 			'change_field_name': 'updateGraphqlFieldName',
+			'render_field_settings': 'updateGraphqlFieldName',
 		},
 		updateGraphqlFieldName: function( $el ) {
 
@@ -16,16 +17,19 @@ $j(document).ready(function () {
 
 			// when a field is emptied, we'll do nothing
 			if ( '' === $nameField || undefined === $nameField ) {
+				field.prop( 'graphql_field_name', '' );
 				return;
 			}
 
 			if ( undefined === $nameField?.getValue() ) {
+				field.prop( 'graphql_field_name', '' );
 				return;
 			}
 
 			var name = $nameField?.getValue() ?? null;
 
 			if ( '' === name ) {
+				field.prop( 'graphql_field_name', '' );
 				return;
 			}
 
@@ -36,7 +40,7 @@ $j(document).ready(function () {
 				var sanitizedGraphqlFieldName = acf.strCamelCase( acf.strSanitize(name) );
 				field.prop( 'graphql_field_name', sanitizedGraphqlFieldName );
 			}
-		}
+		},
 	})
 
 	var GraphqlLocationManager = new acf.Model({


### PR DESCRIPTION
What does this implement/fix? Explain your changes.
---------------------------------------------------
This fixes a bug where the "graphql_field_name" was being set improperly when adding new fields to a field group.

What currently open issues does this close or contribute?
------------------------------------------
closes #57 


Any other comments?
-------------------

### Before:

Here we can see that adding a new field to the field group sets the "graphql field name" value improperly.

![acf-field-before](https://github.com/wp-graphql/wpgraphql-acf/assets/1260765/0d00ffb2-7270-4899-853e-551252dc58c4)

### After:

Here we can see that adding a new field get's the correct "GraphQL Field Name" value set

![acf-field-after](https://github.com/wp-graphql/wpgraphql-acf/assets/1260765/ea84075a-4881-4823-8f3f-352b332a1d6d)
