### PR TITLE
fix: prepare values when return_format is set to "array"

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -3194,16 +3194,16 @@
         },
         {
             "name": "phpunit/phpunit",
-            "version": "9.6.9",
+            "version": "9.6.10",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/phpunit.git",
-                "reference": "a9aceaf20a682aeacf28d582654a1670d8826778"
+                "reference": "a6d351645c3fe5a30f5e86be6577d946af65a328"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/a9aceaf20a682aeacf28d582654a1670d8826778",
-                "reference": "a9aceaf20a682aeacf28d582654a1670d8826778",
+                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/a6d351645c3fe5a30f5e86be6577d946af65a328",
+                "reference": "a6d351645c3fe5a30f5e86be6577d946af65a328",
                 "shasum": ""
             },
             "require": {
@@ -3277,7 +3277,7 @@
             "support": {
                 "issues": "https://github.com/sebastianbergmann/phpunit/issues",
                 "security": "https://github.com/sebastianbergmann/phpunit/security/policy",
-                "source": "https://github.com/sebastianbergmann/phpunit/tree/9.6.9"
+                "source": "https://github.com/sebastianbergmann/phpunit/tree/9.6.10"
             },
             "funding": [
                 {
@@ -3293,7 +3293,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2023-06-11T06:13:56+00:00"
+            "time": "2023-07-10T04:04:23+00:00"
         },
         {
             "name": "psr/container",

--- a/src/FieldConfig.php
+++ b/src/FieldConfig.php
@@ -407,6 +407,18 @@ class FieldConfig {
 			return $value;
 		}
 
+		if ( 'array' === $acf_field_config['return_format'] && is_array( $value ) ) {
+
+			$value = array_map( static function( $opt ) {
+
+				if ( ! is_array( $opt ) ) {
+					return $opt;
+				}
+
+				return $opt['value'] ?? null;
+			}, $value );
+		}
+
 		if ( isset( $acf_field_config['new_lines'] ) ) {
 			if ( 'wpautop' === $acf_field_config['new_lines'] ) {
 				$value = wpautop( $value );

--- a/src/FieldConfig.php
+++ b/src/FieldConfig.php
@@ -407,7 +407,9 @@ class FieldConfig {
 			return $value;
 		}
 
-		if ( 'array' === $acf_field_config['return_format'] && is_array( $value ) ) {
+		// if the value is an array and the field return format is set to array,
+		// map over the array to get the return values
+		if ( isset( $acf_field_config['return_format'] ) && 'array' === $acf_field_config['return_format'] && is_array( $value ) ) {
 
 			$value = array_map( static function( $opt ) {
 

--- a/src/FieldConfig.php
+++ b/src/FieldConfig.php
@@ -411,7 +411,7 @@ class FieldConfig {
 		// map over the array to get the return values
 		if ( isset( $acf_field_config['return_format'] ) && 'array' === $acf_field_config['return_format'] && is_array( $value ) ) {
 
-			$value = array_map( static function( $opt ) {
+			$value = array_map( static function ( $opt ) {
 
 				if ( ! is_array( $opt ) ) {
 					return $opt;


### PR DESCRIPTION
What does this implement/fix? Explain your changes.
---------------------------------------------------

This fixes a bug with fields that set the "return_format" to something other than the default and GraphQL resolver returns errors.

What currently open issues does this close or contribute?
------------------------------------------

closes #61 

Any other comments?
-------------------

Given the following ACF Field Configuration: 

[acf-export-2023-07-07 (1).json.zip](https://github.com/wp-graphql/wpgraphql-acf/files/11986469/acf-export-2023-07-07.1.json.zip)

We could query the fields like so: 

```graphql
{
  post(id: 3410, idType: DATABASE_ID) {
    title
    deleteMe {
      checkboxLabel
      checkboxValue
      checkboxBoth
      selectBotha
      selectLabel
      selectValue
      radioBoth
      radioLabel
      radio
    }
  }
}
```

### BEFORE

We would get errors:

![CleanShot 2023-07-07 at 15 48 41](https://github.com/wp-graphql/wpgraphql-acf/assets/1260765/bfeeb8ba-ef8e-467b-ac71-1fadbe255a4e)

### AFTER

We get the field values
![CleanShot 2023-07-07 at 15 49 36](https://github.com/wp-graphql/wpgraphql-acf/assets/1260765/8c800313-69f7-4a31-b08a-e97d0de763ca)
