### PR TITLE
fix: graphql_description default value incorrect

### DIFF
--- a/src/AcfGraphQLFieldType.php
+++ b/src/AcfGraphQLFieldType.php
@@ -98,15 +98,6 @@ class AcfGraphQLFieldType {
 
 		$default_admin_settings = [];
 
-		// If there's a description provided, use it.
-		if ( ! empty( $field['graphql_description'] ) ) {
-			$description = $field['graphql_description'];
-
-			// fallback to the fields instructions
-		} elseif ( ! empty( $field['instructions'] ) ) {
-			$description = $field['instructions'];
-		}
-
 		$default_admin_settings['show_in_graphql'] = [
 			'label'         => __( 'Show in GraphQL', 'wp-graphql-acf' ),
 			'instructions'  => __( 'Whether the field should be queryable via GraphQL. NOTE: Changing this to false for existing field can cause a breaking change to the GraphQL Schema. Proceed with caution.', 'wp-graphql-acf' ),
@@ -126,7 +117,6 @@ class AcfGraphQLFieldType {
 			'ui'            => true,
 			'default_value' => null,
 			'placeholder'   => __( 'Explanation of how this field should be used in the GraphQL Schema', 'wp-graphql-acf' ),
-			'value'         => ! empty( $description ) ? $description : null,
 			'conditions'    => [
 				'field'    => 'show_in_graphql',
 				'operator' => '==',


### PR DESCRIPTION
What does this implement/fix? Explain your changes.
---------------------------------------------------

When creating a new acf field in a field group that already has fields, the `graphql_description` field was defaulting to the value of the first field in the group. 
 

Does this close any currently open issues?
------------------------------------------
closes #70 



Any other comments?
-------------------

## Before

When adding a new field, we see the "GraphQL Description" inherits the value from the first field:

![acf-field-description-before](https://github.com/wp-graphql/wpgraphql-acf/assets/1260765/e8cd3c32-752e-41d5-b619-f2afd74a3832)


## After

Now "GraphQL Description"  is a blank value when a new field is added:


![acf-field-description-after](https://github.com/wp-graphql/wpgraphql-acf/assets/1260765/171a56fe-8d54-40b3-86a0-2488ccd30d20)

