### PR TITLE
fix: replace `filter_input` with `sanitize_text_field`

### DIFF
--- a/src/Admin/Settings.php
+++ b/src/Admin/Settings.php
@@ -150,7 +150,6 @@ class Settings {
 			wp_send_json( __( 'No form data.', 'wp-graphql-acf' ) );
 		}
 
-		// @phpstan-ignore-next-line
 		if ( empty( $_POST['nonce'] ) || ! wp_verify_nonce( sanitize_text_field( $_POST['nonce'] ), 'wp_graphql_acf' ) ) {
 			wp_send_json_error();
 		}

--- a/src/Admin/Settings.php
+++ b/src/Admin/Settings.php
@@ -151,7 +151,7 @@ class Settings {
 		}
 
 		// @phpstan-ignore-next-line
-		if ( empty( $_POST['nonce'] ) || ! wp_verify_nonce( filter_input( INPUT_POST, 'nonce', FILTER_SANITIZE_STRING ), 'wp_graphql_acf' ) ) {
+		if ( empty( $_POST['nonce'] ) || ! wp_verify_nonce( sanitize_text_field( $_POST['nonce'] ), 'wp_graphql_acf' ) ) {
 			wp_send_json_error();
 		}
 


### PR DESCRIPTION
What does this implement/fix? Explain your changes.
---------------------------------------------------

This replaces the `filter_input` function with `sanitize_text_field` when verifying the nonce for checking Admin Location Rules when ACF Field Group pages are loaded or various settings of the field group are modified. 

The `FILTER_SANITIZE_STRING` argument was deprecated in php 8.1


Does this close any currently open issues?
------------------------------------------
closes #69 


Any other comments?
-------------------

With ACF Pro v6.1.7, WPGraphQL 1.14.9 and WPGraphQL for ACF (v2.0.0-beta.3.1.0) active, when opening the admin page for an ACF Field Group:

### Before

The following error message would be displayed in the console in response to the AJAX method to check the graphql location rules: 

![CleanShot 2023-08-03 at 16 52 19](https://github.com/wp-graphql/wpgraphql-acf/assets/1260765/287dc082-b9d5-4134-8e5f-dd3b34587ebc)


### After

The error message is no longer returned: 


![CleanShot 2023-08-03 at 16 52 40](https://github.com/wp-graphql/wpgraphql-acf/assets/1260765/90e54e9c-1f35-4fd8-8a3b-aa1ec7a89715)
