### PR TITLE
Fix TermNodes returning null when not array and fix type being set to generic TermNode in Taxonomy field

### DIFF
--- a/src/FieldType/Taxonomy.php
+++ b/src/FieldType/Taxonomy.php
@@ -2,6 +2,7 @@
 namespace WPGraphQL\Acf\FieldType;
 
 use WPGraphQL\AppContext;
+use WPGraphQL\Data\Connection\PostObjectConnectionResolver;
 use WPGraphQL\Data\Connection\TermObjectConnectionResolver;
 use WPGraphQL\Acf\AcfGraphQLFieldType;
 use WPGraphQL\Acf\FieldConfig;
@@ -12,44 +13,58 @@ class Taxonomy {
 	 * @return void
 	 */
 	public static function register_field_type(): void {
-		register_graphql_acf_field_type(
-			'taxonomy',
-			[
-				'exclude_admin_fields' => [ 'graphql_non_null' ],
-				'graphql_type'         => static function ( FieldConfig $field_config, AcfGraphQLFieldType $acf_field_type ) {
-					$connection_config = [
-						'toType'  => 'TermNode',
-						'resolve' => static function ( $root, $args, AppContext $context, $info ) use ( $field_config ) {
-							$value = $field_config->resolve_field( $root, $args, $context, $info );
 
-							if ( empty( $value ) || ! is_array( $value ) ) {
-								return null;
-							}
+		register_graphql_acf_field_type( 'taxonomy', [
+			'exclude_admin_fields' => [ 'graphql_non_null' ],
+			'graphql_type'         => function ( FieldConfig $field_config, AcfGraphQLFieldType $acf_field_type ) {
+				$type = 'TermNode';
+				
+				$acf_field = $field_config->get_acf_field();
+				if ( isset( $acf_field['taxonomy'] ) ) {
+					$tax_object = get_taxonomy( $acf_field['taxonomy'] );
+					if ( isset( $tax_object->graphql_single_name ) ) {
+						$type = $tax_object->graphql_single_name;
+						graphql_debug( var_export($type, true), [ 'type' => 'ARGS_BREAKPOINT' ] );
+					}
+				}
 
-							$value = array_map(
-								static function ( $id ) {
-									return absint( $id );
-								},
-								$value 
-							);
 
-							$resolver = new TermObjectConnectionResolver( $root, $args, $context, $info );
-							return $resolver
+				$connection_config = [
+					'toType'  => $type,
+					'resolve' => static function ( $root, $args, AppContext $context, $info ) use ( $field_config ) {
+						$value = $field_config->resolve_field( $root, $args, $context, $info );
+
+
+						
+						if ( empty( $value )) {
+							return null;
+						}
+						if ( ! empty( $value ) && is_array( $value ) ) {
+							$value = array_map(static function ( $id ) {
+								return absint( $id );
+							}, $value );
+						}
+
+
+
+
+						$resolver = new TermObjectConnectionResolver( $root, $args, $context, $info );
+						return $resolver
 							// Set the query to include only the IDs passed in from the field
 							// and orderby the ids
 							->set_query_arg( 'include', $value )
 							->set_query_arg( 'orderby', 'include' )
 							->get_connection();
-						},
-					];
+					},
+				];
 
-					$field_config->register_graphql_connections( $connection_config );
+				$field_config->register_graphql_connections( $connection_config );
 
-					// Return null because registering a connection adds it to the Schema for us
-					return 'connection';
-				},
-			] 
-		);
+				// Return null because registering a connection adds it to the Schema for us
+				return 'connection';
+			},
+		] );
+
 	}
 
 }

--- a/src/FieldType/Taxonomy.php
+++ b/src/FieldType/Taxonomy.php
@@ -25,7 +25,7 @@ class Taxonomy {
 							if ( empty( $value )) {
 								return null;
 							}
-							if ( ! empty( $value ) && is_array( $value ) ) {
+							if ( is_array( $value ) ) {
 								$value = array_map(
 									static function ( $id ) {
 										return absint( $id );

--- a/src/FieldType/Taxonomy.php
+++ b/src/FieldType/Taxonomy.php
@@ -2,7 +2,6 @@
 namespace WPGraphQL\Acf\FieldType;
 
 use WPGraphQL\AppContext;
-use WPGraphQL\Data\Connection\PostObjectConnectionResolver;
 use WPGraphQL\Data\Connection\TermObjectConnectionResolver;
 use WPGraphQL\Acf\AcfGraphQLFieldType;
 use WPGraphQL\Acf\FieldConfig;
@@ -13,58 +12,54 @@ class Taxonomy {
 	 * @return void
 	 */
 	public static function register_field_type(): void {
-
-		register_graphql_acf_field_type( 'taxonomy', [
-			'exclude_admin_fields' => [ 'graphql_non_null' ],
-			'graphql_type'         => function ( FieldConfig $field_config, AcfGraphQLFieldType $acf_field_type ) {
-				$type = 'TermNode';
+		register_graphql_acf_field_type(
+			'taxonomy',
+			[
+				'exclude_admin_fields' => [ 'graphql_non_null' ],
+				'graphql_type'         => static function ( FieldConfig $field_config, AcfGraphQLFieldType $acf_field_type ) {
+					$type = 'TermNode';
 				
-				$acf_field = $field_config->get_acf_field();
-				if ( isset( $acf_field['taxonomy'] ) ) {
-					$tax_object = get_taxonomy( $acf_field['taxonomy'] );
-					if ( isset( $tax_object->graphql_single_name ) ) {
-						$type = $tax_object->graphql_single_name;
-						graphql_debug( var_export($type, true), [ 'type' => 'ARGS_BREAKPOINT' ] );
+					$acf_field = $field_config->get_acf_field();
+
+					if ( isset( $acf_field['taxonomy'] ) ) {
+						$tax_object = get_taxonomy( $acf_field['taxonomy'] );
+						if ( isset( $tax_object->graphql_single_name ) ) {
+							$type = $tax_object->graphql_single_name;
+							graphql_debug( var_export($type, true), [ 'type' => 'ARGS_BREAKPOINT' ] );
+						}
 					}
-				}
 
+					$connection_config = [
+						'toType'  => 'TermNode',
+						'resolve' => static function ( $root, $args, AppContext $context, $info ) use ( $field_config ) {
+							$value = $field_config->resolve_field( $root, $args, $context, $info );
 
-				$connection_config = [
-					'toType'  => $type,
-					'resolve' => static function ( $root, $args, AppContext $context, $info ) use ( $field_config ) {
-						$value = $field_config->resolve_field( $root, $args, $context, $info );
+							if ( empty( $value )) {
+								return null;
+							}
+							if ( ! empty( $value ) && is_array( $value ) ) {
+								$value = array_map(static function ( $id ) {
+									return absint( $id );
+								}, $value );
+							}
 
-
-						
-						if ( empty( $value )) {
-							return null;
-						}
-						if ( ! empty( $value ) && is_array( $value ) ) {
-							$value = array_map(static function ( $id ) {
-								return absint( $id );
-							}, $value );
-						}
-
-
-
-
-						$resolver = new TermObjectConnectionResolver( $root, $args, $context, $info );
-						return $resolver
+							$resolver = new TermObjectConnectionResolver( $root, $args, $context, $info );
+							return $resolver
 							// Set the query to include only the IDs passed in from the field
 							// and orderby the ids
 							->set_query_arg( 'include', $value )
 							->set_query_arg( 'orderby', 'include' )
 							->get_connection();
-					},
-				];
+						},
+					];
 
-				$field_config->register_graphql_connections( $connection_config );
+					$field_config->register_graphql_connections( $connection_config );
 
-				// Return null because registering a connection adds it to the Schema for us
-				return 'connection';
-			},
-		] );
-
+					// Return null because registering a connection adds it to the Schema for us
+					return 'connection';
+				},
+			] 
+		);
 	}
 
 }

--- a/src/FieldType/Taxonomy.php
+++ b/src/FieldType/Taxonomy.php
@@ -22,7 +22,7 @@ class Taxonomy {
 						'resolve' => static function ( $root, $args, AppContext $context, $info ) use ( $field_config ) {
 							$value = $field_config->resolve_field( $root, $args, $context, $info );
 
-							if ( empty( $value )) {
+							if ( empty( $value ) ) {
 								return null;
 							}
 							if ( is_array( $value ) ) {

--- a/src/FieldType/Taxonomy.php
+++ b/src/FieldType/Taxonomy.php
@@ -37,9 +37,12 @@ class Taxonomy {
 								return null;
 							}
 							if ( ! empty( $value ) && is_array( $value ) ) {
-								$value = array_map(static function ( $id ) {
-									return absint( $id );
-								}, $value );
+								$value = array_map(
+									static function ( $id ) {
+										return absint( $id );
+									},
+									$value 
+								);
 							}
 
 							$resolver = new TermObjectConnectionResolver( $root, $args, $context, $info );

--- a/src/FieldType/Taxonomy.php
+++ b/src/FieldType/Taxonomy.php
@@ -25,7 +25,6 @@ class Taxonomy {
 						$tax_object = get_taxonomy( $acf_field['taxonomy'] );
 						if ( isset( $tax_object->graphql_single_name ) ) {
 							$type = $tax_object->graphql_single_name;
-							graphql_debug( var_export($type, true), [ 'type' => 'ARGS_BREAKPOINT' ] );
 						}
 					}
 

--- a/src/FieldType/Taxonomy.php
+++ b/src/FieldType/Taxonomy.php
@@ -17,17 +17,6 @@ class Taxonomy {
 			[
 				'exclude_admin_fields' => [ 'graphql_non_null' ],
 				'graphql_type'         => static function ( FieldConfig $field_config, AcfGraphQLFieldType $acf_field_type ) {
-					$type = 'TermNode';
-				
-					$acf_field = $field_config->get_acf_field();
-
-					if ( isset( $acf_field['taxonomy'] ) ) {
-						$tax_object = get_taxonomy( $acf_field['taxonomy'] );
-						if ( isset( $tax_object->graphql_single_name ) ) {
-							$type = $tax_object->graphql_single_name;
-						}
-					}
-
 					$connection_config = [
 						'toType'  => 'TermNode',
 						'resolve' => static function ( $root, $args, AppContext $context, $info ) use ( $field_config ) {


### PR DESCRIPTION
<!--

### Your checklist for this pull request
Thanks for sending a pull request! Please make sure you click the link above to view the contribution guidelines, then fill out the blanks below.

-->

What does this implement/fix? Explain your changes.
---------------------------------------------------
Taxonomy field was returning null when field_type was set to return a single value (with select or radio button). By not returning null in case it is not an array (which is the default return when these field types are selected), it properly returns the term.
![Before](https://i.ibb.co/7Wk67Cf/before-0.png)

Also the type was being set to generic TermNode type, which did not allow to query custom fields inside these fields. By setting the type correctly to the taxonomy name it works properly
![Before](https://i.ibb.co/8PptkrB/before-1.png)

After changing these everything works as expected
![Before](https://i.ibb.co/pwT6q45/after.png)


Does this close any currently open issues?
------------------------------------------
<!--
### Write "closes #{pr number}"
### see: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->


Any relevant logs, error output, GraphiQL screenshots, etc?
-------------------------------------
(If it’s long, please paste to https://ghostbin.com/ and insert the link here.)


Any other comments?
-------------------
…


Where has this been tested?
---------------------------
**Operating System:** …

**WordPress Version:** …
