### PR TITLE
feat: provide UIs for showing ACF Option Pages in the GraphQL Schema

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,16 @@
 # Changelog
 
-## 2.0.0-beta.4.1.0
+## 2.0.0-beta.5.0.0
+
+### New Features
+
+- [#81](https://github.com/wp-graphql/wpgraphql-acf/pull/81): feat: 🚀 ACF Blocks Support. Query ACF Blocks using WPGraphQL!! 🚀 (when [WPGraphQL Content Blocks v1.2.0+](https://github.com/wpengine/wp-graphql-content-blocks/releases/) is active)
 
 ### Chores / Bugfixes
 
 - [#77](https://github.com/wp-graphql/wpgraphql-acf/pull/77): fix: js error when clone fields are added to a field group.
+- [#80](https://github.com/wp-graphql/wpgraphql-acf/pull/81): ci: put the files in a subfolder when build zip in github
+
 
 ## v2.0.0-beta.4.0.0
 

--- a/src/Admin/OptionsPageRegistration.php
+++ b/src/Admin/OptionsPageRegistration.php
@@ -1,0 +1,167 @@
+<?php
+namespace WPGraphQL\Acf\Admin;
+
+use WPGraphQL\Utils\Utils;
+
+class OptionsPageRegistration {
+
+	/**
+	 * @return void
+	 */
+	public function init(): void {
+
+		// Add GraphQL columns to the ACF Options Page registration columns
+		// NOTE: the priority must be lower (a bigger number) than 10 to not conflict
+		// with the default ACF columns filter
+		add_filter( 'manage_acf-ui-options-page_posts_columns', [ $this, 'add_graphql_type_column' ], 20, 1 );
+
+		// Display the GraphQL Type in the ACF Taxonomy Registration Columns
+		add_action( 'manage_acf-ui-options-page_posts_custom_column', [ $this, 'render_graphql_columns' ], 10, 2 );
+
+		// Add registration fields to the ACF Options Pages output for exporting / saving as PHP
+		add_filter( 'acf/ui_options_page/registration_args', [ $this, 'add_registration_fields' ], 10, 2 );
+
+		// Add tha GraphQL Tab to the ACF Post Type registration screen
+		add_filter( 'acf/ui_options_page/additional_settings_tabs', [ $this, 'add_tabs' ] );
+
+		// Render the graphql settings tab in the ACF post type registration screen
+		add_action( 'acf/ui_options_page/render_settings_tab/graphql', [ $this, 'render_settings_tab' ] );
+	}
+
+	/**
+	 * @param array $args
+	 * @param array $post
+	 *
+	 * @return array
+	 */
+	public function add_registration_fields( array $args, array $post ) : array {
+		$show_in_graphql = false;
+
+		if ( isset( $args['show_in_graphql'] ) ) {
+			$show_in_graphql = $args['show_in_graphql'];
+		} elseif ( isset( $post['show_in_graphql'] ) ) {
+			$show_in_graphql = $post['show_in_graphql'];
+		}
+
+		$args['show_in_graphql'] = $show_in_graphql;
+
+		$graphql_type_name = '';
+
+		if ( ! empty( $args['graphql_type_name'] ) ) {
+			$graphql_type_name = $args['graphql_type_name'];
+		} elseif ( ! empty( $post['graphql_type_name'] ) ) {
+			$graphql_type_name = $post['graphql_type_name'];
+		} elseif ( isset( $args['page_title'] ) ) {
+			$graphql_type_name = Utils::format_field_name( $args['page_title'], false );
+		}
+
+		// if a graphql_single_name exists, use it, otherwise use the formatted version of the singular_name label
+		$args['graphql_type_name'] = $graphql_type_name;
+
+		return $args;
+	}
+
+	/**
+	 * @param array $tabs
+	 *
+	 * @return array
+	 */
+	public function add_tabs( array $tabs ): array {
+		$tabs['graphql'] = __( 'GraphQL', 'wp-graphql-acf' );
+		return $tabs;
+	}
+
+	/**
+	 * @param array $acf_ui_options_page
+	 *
+	 * @return void
+	 */
+	public function render_settings_tab( array $acf_ui_options_page ): void {
+		acf_render_field_wrap(
+			[
+				'type'         => 'true_false',
+				'name'         => 'show_in_graphql',
+				'key'          => 'show_in_graphql',
+				'prefix'       => 'acf_ui_options_page',
+				'value'        => isset( $acf_ui_options_page['show_in_graphql'] ) && true === (bool) $acf_ui_options_page['show_in_graphql'] ? 1 : 0,
+				'ui'           => true,
+				'label'        => __( 'Show in GraphQL', 'wp-graphql-acf' ),
+				'instructions' => __( 'Whether to show the Post Type in the WPGraphQL Schema.', 'wp-graphql-acf' ),
+				'default'      => false,
+			]
+		);
+
+		$graphql_type_name = $acf_ui_options_page['graphql_type_name'] ?? '';
+
+		if ( empty( $graphql_type_name ) ) {
+			$graphql_type_name = ! empty( $acf_ui_options_page['page_title'] ) ? Utils::format_field_name( $acf_ui_options_page['page_title'], true ) : '';
+		}
+
+		$graphql_type_name = Utils::format_field_name( $graphql_type_name, true );
+
+		acf_render_field_wrap(
+			[
+				'type'         => 'text',
+				'name'         => 'graphql_type_name',
+				'key'          => 'graphql_type_name',
+				'prefix'       => 'acf_ui_options_page',
+				'value'        => $graphql_type_name,
+				'label'        => __( 'GraphQL Type Name', 'wp-graphql-acf' ),
+				'instructions' => __( 'How the Options Page should be referenced in the GraphQL Schema.', 'wp-graphql-acf' ),
+				'default'      => $graphql_type_name,
+				'required'     => 1,
+				'conditions'   => [
+					'field'    => 'show_in_graphql',
+					'operator' => '==',
+					'value'    => '1',
+				],
+			],
+			'div',
+			'field'
+		);
+	}
+
+	/**
+	 * Given a list of columns, add "graphql_type" as a column.
+	 *
+	 * @param array $columns The columns on the post type table
+	 *
+	 * @return array
+	 */
+	public function add_graphql_type_column( array $columns ): array {
+		$columns['show_in_graphql'] = __( 'Show in GraphQL', 'wp-graphql-acf' );
+		$columns['graphql_type']    = __( 'GraphQL Type', 'wp-graphql-acf' );
+		return $columns;
+	}
+
+	/**
+	 * Determine and echo the markup to show for the graphql_type column
+	 *
+	 * @param string $column_name The name of the column being rendered
+	 * @param int    $post_id     The ID of the post the column is being displayed for
+	 *
+	 * @return void
+	 */
+	public function render_graphql_columns( string $column_name, int $post_id ): void {
+		$post_type = acf_get_internal_post_type( $post_id, 'acf-ui-options-page' );
+
+		// if there's no post type, bail early
+		if ( empty( $post_type ) ) {
+			return;
+		}
+
+		// Determine the output for the column
+		switch ( $column_name ) {
+			case 'graphql_type':
+				$graphql_type = Utils::format_type_name( \WPGraphQL\Acf\Utils::get_field_group_name( $post_type ) );
+				echo esc_html( $graphql_type );
+				break;
+			case 'show_in_graphql':
+				$show = isset( $post_type['show_in_graphql'] ) && true === (bool) $post_type['show_in_graphql'] ? 'true' : 'false';
+				echo esc_html( $show );
+				break;
+			default:
+		}
+	}
+
+}

--- a/src/LocationRules/LocationRules.php
+++ b/src/LocationRules/LocationRules.php
@@ -902,7 +902,6 @@ class LocationRules {
 				return;
 			}
 
-			// Show all options pages
 			foreach ( $acf_blocks as $acf_block ) {
 				if ( ! isset( $acf_block['show_in_graphql'] ) || false === (bool) $acf_block['show_in_graphql'] ) {
 					continue;
@@ -911,7 +910,6 @@ class LocationRules {
 				$this->set_graphql_type( $field_group_name, $type_name );
 			}
 
-			// Get the options page to unset
 			$acf_block = acf_get_block_type( $value );
 			if ( ! isset( $acf_block['show_in_graphql'] ) || false === $acf_block['show_in_graphql'] ) {
 				return;
@@ -956,7 +954,13 @@ class LocationRules {
 				if ( ! isset( $options_page['show_in_graphql'] ) || false === (bool) $options_page['show_in_graphql'] ) {
 					continue;
 				}
-				$type_name = isset( $options_page['graphql_field_name'] ) ? Utils::format_type_name( $options_page['graphql_field_name'] ) : Utils::format_type_name( $options_page['menu_slug'] );
+
+				if ( ! empty( $options_page['graphql_single_name'] ) ) {
+					$type_name = Utils::format_type_name( $options_page['graphql_single_name'] );
+				} else {
+					$type_name = isset( $options_page['graphql_type_name'] ) ? Utils::format_type_name( $options_page['graphql_type_name'] ) : Utils::format_type_name( $options_page['menu_slug'] );
+				}
+
 				$this->set_graphql_type( $field_group_name, $type_name );
 			}
 
@@ -965,7 +969,11 @@ class LocationRules {
 			if ( ! isset( $options_page['show_in_graphql'] ) || false === $options_page['show_in_graphql'] ) {
 				return;
 			}
-			$type_name = isset( $options_page['graphql_field_name'] ) ? Utils::format_type_name( $options_page['graphql_field_name'] ) : Utils::format_type_name( $options_page['menu_slug'] );
+			if ( ! empty( $options_page['graphql_single_name'] ) ) {
+				$type_name = Utils::format_type_name( $options_page['graphql_single_name'] );
+			} else {
+				$type_name = isset( $options_page['graphql_type_name'] ) ? Utils::format_type_name( $options_page['graphql_type_name'] ) : Utils::format_type_name( $options_page['menu_slug'] );
+			}
 			$this->unset_graphql_type( $field_group_name, $type_name );
 		}
 	}

--- a/src/ThirdParty/WPGraphQLContentBlocks/WPGraphQLContentBlocks.php
+++ b/src/ThirdParty/WPGraphQLContentBlocks/WPGraphQLContentBlocks.php
@@ -3,8 +3,16 @@ namespace WPGraphQL\Acf\ThirdParty\WPGraphQLContentBlocks;
 
 class WPGraphQLContentBlocks {
 
+	/**
+	 * Initialize support for WPGraphQL Content Blocks
+	 *
+	 * @return void
+	 */
 	public function init(): void {
-		if ( ! defined( 'WPGRAPHQL_CONTENT_BLOCKS_DIR' ) ) {
+
+		// If WPGraphQL Content Blocks is not active, or is active with a version prior to 1.2.0, don't
+		// instantiate this functionality
+		if ( ! defined( 'WPGRAPHQL_CONTENT_BLOCKS_VERSION' ) || version_compare( WPGRAPHQL_CONTENT_BLOCKS_VERSION, '1.2.0', 'lt' ) ) {
 			return;
 		}
 
@@ -16,6 +24,7 @@ class WPGraphQLContentBlocks {
 
 		// @see: https://github.com/wpengine/wp-graphql-content-blocks/pull/148
 		add_filter( 'wpgraphql_content_blocks_should_apply_post_type_editor_blocks_interfaces', [ $this, 'filter_editor_block_interfaces' ], 10, 7 );
+
 	}
 
 	/**
@@ -55,7 +64,7 @@ class WPGraphQLContentBlocks {
 						'type' => 'String',
 					],
 				],
-			] 
+			]
 		);
 	}
 

--- a/src/Utils.php
+++ b/src/Utils.php
@@ -139,9 +139,11 @@ class Utils {
 			return $options_pages;
 		}
 		$acf_options_pages = acf_get_options_pages();
+
 		if ( empty( $acf_options_pages ) || ! is_array( $acf_options_pages ) ) {
 			return $options_pages;
 		}
+
 		return array_filter(
 			array_map(
 				static function ( $option_page ) {
@@ -275,7 +277,6 @@ class Utils {
 	public static function should_field_group_show_in_graphql( array $acf_field_group ): bool {
 		$should = true;
 
-
 		$show_in_rest = $acf_field_group['show_in_rest'] ?? false;
 
 
@@ -309,6 +310,8 @@ class Utils {
 		if ( ! empty( $field_group['graphql_field_name'] ) ) {
 			$field_group_name = $field_group['graphql_field_name'];
 			$field_group_name = preg_replace( '/[^0-9a-zA-Z_\s]/i', '', $field_group_name );
+		} elseif ( ! empty( $field_group['graphql_type_name'] ) ) {
+			$field_group_name = \WPGraphQL\Utils\Utils::format_field_name( $field_group['graphql_type_name'], true );
 		} else {
 			if ( ! empty( $field_group['name'] ) ) {
 				$field_group_name = $field_group['name'];

--- a/src/WPGraphQLAcf.php
+++ b/src/WPGraphQLAcf.php
@@ -4,6 +4,7 @@ use WPGraphQL\Registry\TypeRegistry;
 
 use WPGraphQL\Acf\Admin\PostTypeRegistration;
 use WPGraphQL\Acf\Admin\TaxonomyRegistration;
+use WPGraphQL\Acf\Admin\OptionsPageRegistration;
 use WPGraphQL\Acf\Registry;
 use WPGraphQL\Acf\ThirdParty;
 
@@ -34,7 +35,7 @@ class WPGraphQLAcf {
 
 		add_action( 'wpgraphql/acf/init', [ $this, 'init_third_party_support' ] );
 		add_action( 'admin_init', [ $this, 'init_admin_settings' ] );
-		add_action( 'after_setup_theme', [ $this, 'cpt_tax_registration' ] );
+		add_action( 'after_setup_theme', [ $this, 'acf_internal_post_type_support' ] );
 		add_action( 'graphql_register_types', [ $this, 'init_registry' ] );
 
 		add_filter( 'graphql_data_loaders', [ $this, 'register_loaders' ], 10, 2 );
@@ -65,12 +66,15 @@ class WPGraphQLAcf {
 	 *
 	 * @return void
 	 */
-	public function cpt_tax_registration(): void {
+	public function acf_internal_post_type_support(): void {
 		$taxonomy_registration_screen = new TaxonomyRegistration();
 		$taxonomy_registration_screen->init();
 
 		$cpt_registration_screen = new PostTypeRegistration();
 		$cpt_registration_screen->init();
+
+		$options_page_registration_screen = new OptionsPageRegistration();
+		$options_page_registration_screen->init();
 	}
 
 	/**

--- a/tests/wpunit/LocationRulesTest.php
+++ b/tests/wpunit/LocationRulesTest.php
@@ -588,7 +588,7 @@ class LocationRulesTest extends \Tests\WPGraphQL\Acf\WPUnit\WPGraphQLAcfTestCase
 			'menu_slug'     => 'theme-general-settings',
 			'capability'    => 'edit_posts',
 			'redirect'      => false,
-			'graphql_single_name'
+			'show_in_graphql' => 1
 		));
 
 		$this->clearSchema();

--- a/tests/wpunit/OptionsPageTest.php
+++ b/tests/wpunit/OptionsPageTest.php
@@ -182,7 +182,7 @@ class OptionsPageTest extends \Tests\WPGraphQL\Acf\WPUnit\WPGraphQLAcfTestCase {
 				'menu_slug'  => 'custom-graphql-name',
 				'capability' => 'edit_posts',
 				// options pages will show in the Schema unless set to false
-				'graphql_field_name'   => 'MyCustomOptionsName',
+				'graphql_type_name'   => 'MyCustomOptionsName',
 			]
 		);
 
@@ -255,7 +255,7 @@ class OptionsPageTest extends \Tests\WPGraphQL\Acf\WPUnit\WPGraphQLAcfTestCase {
 				'menu_slug'  => 'options-page-node',
 				'capability' => 'edit_posts',
 				// options pages will show in the Schema unless set to false
-				'graphql_field_name'   => 'OptionsPageNode',
+				'graphql_type_name'   => 'OptionsPageNode',
 			]
 		);
 

--- a/wp-graphql-acf.php
+++ b/wp-graphql-acf.php
@@ -4,7 +4,7 @@
  * Description: Re-imagining the WPGraphQL for ACF plugin
  * Author: WPGraphQL, Jason Bahl
  * Author URI: https://www.wpgraphql.com
- * Version: 2.0.0-beta.4.1.0
+ * Version: 2.0.0-beta.5.0.0
  * Text Domain: wp-graphql-acf
  * Requires PHP: 7.3
  * Requires at least: 5.9
@@ -29,7 +29,7 @@ if ( file_exists( __DIR__ . '/vendor/autoload.php' ) ) {
 }
 
 if ( ! defined( 'WPGRAPHQL_FOR_ACF_VERSION' ) ) {
-	define( 'WPGRAPHQL_FOR_ACF_VERSION', '2.0.0-beta.4.1.0' );
+	define( 'WPGRAPHQL_FOR_ACF_VERSION', '2.0.0-beta.5.0.0' );
 }
 
 if ( ! defined( 'WPGRAPHQL_FOR_ACF_VERSION_WPGRAPHQL_REQUIRED_MIN_VERSION' ) ) {


### PR DESCRIPTION
What does this implement/fix? Explain your changes.
---------------------------------------------------
[ACF Pro v6.2](https://www.advancedcustomfields.com/blog/acf-6-2-0-released/) introduced a UI for creating ACF Option Pages. 

This PR brings support for configuring those option pages to show in GraphQL and set the GraphQL Type Name to represent the options page. 

Here's how it works 👇🏻 

### Configure Options Page

When registering an Options Page via the ACF PRO v6.2+ UI, you can configure the Options Page to show in graphql, and set the GraphQL Type Name.

![CleanShot 2023-09-06 at 15 22 22](https://github.com/wp-graphql/wpgraphql-acf/assets/1260765/fc73c124-3d70-4356-a50b-a5a0c474b89c)

You will see the data in the columns on the list options page as well:

![CleanShot 2023-09-06 at 15 27 55](https://github.com/wp-graphql/wpgraphql-acf/assets/1260765/b993cdcd-3edb-4197-b293-f48d19bdd237)

### Assign a Field Group

If you assign an ACF Field Group to the Options Page:

![CleanShot 2023-09-06 at 15 28 53](https://github.com/wp-graphql/wpgraphql-acf/assets/1260765/f875b6a4-8731-4740-b363-297d36c94efa)

You will be able to see that the ACF Field Group is associated with the Options Page Type

![CleanShot 2023-09-06 at 15 29 33](https://github.com/wp-graphql/wpgraphql-acf/assets/1260765/d927b3b6-1a0c-40be-a7c8-9aafeeb746c7)


### Query the Options

Then you can fill in values for the options page:

![CleanShot 2023-09-06 at 15 30 35](https://github.com/wp-graphql/wpgraphql-acf/assets/1260765/132c0d5f-f1e7-422f-9a22-92b67dd23f9e)

And query for the options in GraphQL:

![CleanShot 2023-09-06 at 15 31 47](https://github.com/wp-graphql/wpgraphql-acf/assets/1260765/c98eb179-bb31-42a6-8722-09f4af41e2e8)


Does this close any currently open issues?
------------------------------------------
closes #83 


Any other comments?
-------------------
Folks using JSON or PHP to register options pages can still do so as they did before, adding fields `graphql_type_name` and `show_in_graphql`: 

```php
acf_add_options_page(
	[
		'page_title' => 'OptionsPageNode',
		'menu_title' => __( 'Options Page Node' ),
		'menu_slug'  => 'options-page-node',
		'capability' => 'edit_posts',
		show_in_graphql' => true,
		'graphql_type_name'   => 'OptionsPageNode',
	]
);
```