### PR TITLE
fix: #92 acf block tests

### DIFF
--- a/codeception.dist.yml
+++ b/codeception.dist.yml
@@ -76,11 +76,11 @@ modules:
         - '%ACF_EXTENDED_PLUGIN_SLUG%'
         - wp-graphql/wp-graphql.php
         - wp-graphql-acf/wp-graphql-acf.php
-        - wp-graphql-content-blocks/wp-graphql-content-blocks.php
+        - '%WPGRAPHQL_CONTENT_BLOCKS_PLUGIN_SLUG%'
       activatePlugins:
         - '%ACF_PLUGIN_SLUG%'
         - '%ACF_EXTENDED_PLUGIN_SLUG%'
         - wp-graphql/wp-graphql.php
         - wp-graphql-acf/wp-graphql-acf.php
-        - wp-graphql-content-blocks/wp-graphql-content-blocks.php
+        - '%WPGRAPHQL_CONTENT_BLOCKS_PLUGIN_SLUG%'
       configFile: 'tests/_data/config.php'

--- a/codeception.dist.yml
+++ b/codeception.dist.yml
@@ -76,9 +76,11 @@ modules:
         - '%ACF_EXTENDED_PLUGIN_SLUG%'
         - wp-graphql/wp-graphql.php
         - wp-graphql-acf/wp-graphql-acf.php
+        - wp-graphql-content-blocks/wp-graphql-content-blocks.php
       activatePlugins:
         - '%ACF_PLUGIN_SLUG%'
         - '%ACF_EXTENDED_PLUGIN_SLUG%'
         - wp-graphql/wp-graphql.php
         - wp-graphql-acf/wp-graphql-acf.php
+        - wp-graphql-content-blocks/wp-graphql-content-blocks.php
       configFile: 'tests/_data/config.php'

--- a/composer.lock
+++ b/composer.lock
@@ -3069,16 +3069,16 @@
         },
         {
             "name": "nesbot/carbon",
-            "version": "2.70.0",
+            "version": "2.71.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/briannesbitt/Carbon.git",
-                "reference": "d3298b38ea8612e5f77d38d1a99438e42f70341d"
+                "reference": "98276233188583f2ff845a0f992a235472d9466a"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/briannesbitt/Carbon/zipball/d3298b38ea8612e5f77d38d1a99438e42f70341d",
-                "reference": "d3298b38ea8612e5f77d38d1a99438e42f70341d",
+                "url": "https://api.github.com/repos/briannesbitt/Carbon/zipball/98276233188583f2ff845a0f992a235472d9466a",
+                "reference": "98276233188583f2ff845a0f992a235472d9466a",
                 "shasum": ""
             },
             "require": {
@@ -3171,7 +3171,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2023-09-07T16:43:50+00:00"
+            "time": "2023-09-25T11:31:05+00:00"
         },
         {
             "name": "nikic/php-parser",
@@ -3714,16 +3714,16 @@
         },
         {
             "name": "phpstan/phpdoc-parser",
-            "version": "1.24.1",
+            "version": "1.24.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/phpstan/phpdoc-parser.git",
-                "reference": "9f854d275c2dbf84915a5c0ec9a2d17d2cd86b01"
+                "reference": "bcad8d995980440892759db0c32acae7c8e79442"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpstan/phpdoc-parser/zipball/9f854d275c2dbf84915a5c0ec9a2d17d2cd86b01",
-                "reference": "9f854d275c2dbf84915a5c0ec9a2d17d2cd86b01",
+                "url": "https://api.github.com/repos/phpstan/phpdoc-parser/zipball/bcad8d995980440892759db0c32acae7c8e79442",
+                "reference": "bcad8d995980440892759db0c32acae7c8e79442",
                 "shasum": ""
             },
             "require": {
@@ -3755,9 +3755,9 @@
             "description": "PHPDoc parser with support for nullable, intersection and generic types",
             "support": {
                 "issues": "https://github.com/phpstan/phpdoc-parser/issues",
-                "source": "https://github.com/phpstan/phpdoc-parser/tree/1.24.1"
+                "source": "https://github.com/phpstan/phpdoc-parser/tree/1.24.2"
             },
-            "time": "2023-09-18T12:18:02+00:00"
+            "time": "2023-09-26T12:28:12+00:00"
         },
         {
             "name": "phpstan/phpstan",

--- a/docker/app.setup.sh
+++ b/docker/app.setup.sh
@@ -12,7 +12,7 @@ ACF_PRO=${ACF_PRO-false}
 #WPGRAPHQL_CONTENT_BLOCKS_VERSION=${WPGRAPHQL_CONTENT_BLOCKS_VERSION-"latest"}
 #
 #// fallback to hello.php as a hack. dont love this, but we have to pass a slug.
-#export WPGRAPHQL_CONTENT_BLOCKS_PLUGIN_SLUG=${WPGRAPHQL_CONTENT_BLOCKS_PLUGIN_SLUG-'wp-graphql-content-blocks/wp-graphql-content-blocks.php'}
+export WPGRAPHQL_CONTENT_BLOCKS_PLUGIN_SLUG=${WPGRAPHQL_CONTENT_BLOCKS_PLUGIN_SLUG-'hello.php'}
 
 # Export the plugin slug for use when running the codeception tests
 # (The slug is different for Free and Pro)
@@ -143,7 +143,8 @@ if [[ 'true' = "${WPGRAPHQL_CONTENT_BLOCKS}" ]]; then
 ## If WPGRAPHQL_CONTENT_BLOCKS is not true, skip installing it
 else
 	echo "Skipping installing WPGraphQL Content Blocks"
-	WPGRAPHQL_CONTENT_BLOCKS_PLUGIN_SLUG='wp-graphql-content-blocks/wp-graphql-content-blocks.php';
+	wp plugin activate "hello" --allow-root
+	WPGRAPHQL_CONTENT_BLOCKS_PLUGIN_SLUG='hello.php';
 fi
 
 ## List the plugins that were activated to ensure ACF Free or Pro was properly activated

--- a/docker/app.setup.sh
+++ b/docker/app.setup.sh
@@ -124,27 +124,27 @@ else
 
 fi
 
-#echo "WPGRAPHQL_CONTENT_BLOCKS: ${WPGRAPHQL_CONTENT_BLOCKS}"
-#
-## If WPGraphQL Content Blocks should be tested against
-#if [[ 'true' = "${WPGRAPHQL_CONTENT_BLOCKS}" ]]; then
-#
-#	WPGRAPHQL_CONTENT_BLOCKS_PLUGIN_SLUG='wp-graphql-content-blocks/wp-graphql-content-blocks.php';
-#
-#	if [[ -z ${WPGRAPHQL_CONTENT_BLOCKS_VERSION} || "${WPGRAPHQL_CONTENT_BLOCKS_VERSION}" == "latest" ]]; then
-#	  # Get latest release version of WPGraphQL Content Blocks
-#	  echo "Getting the latest version of WPGraphQL Content Blocks"
-#	  WPGRAPHQL_CONTENT_BLOCKS_VERSION=$(curl --location --request GET "https://api.github.com/repos/wpengine/wp-graphql-content-blocks/releases/latest" | jq '.tag_name' | tr -d '"' )
-#	fi
-#
-#	echo "Installing WPGraphQL Content Blocks ${WPGRAPHQL_CONTENT_BLOCKS_VERSION}"
-#    wp plugin install "https://github.com/wpengine/wp-graphql-content-blocks/releases/download/${WPGRAPHQL_CONTENT_BLOCKS_VERSION}/wp-graphql-content-blocks.zip" --allow-root --activate
-#
-### If WPGRAPHQL_CONTENT_BLOCKS is not true, skip installing it
-#else
-#	echo "Skipping installing WPGraphQL Content Blocks"
-#	WPGRAPHQL_CONTENT_BLOCKS_PLUGIN_SLUG='wp-graphql-content-blocks/wp-graphql-content-blocks.php';
-#fi
+echo "WPGRAPHQL_CONTENT_BLOCKS: ${WPGRAPHQL_CONTENT_BLOCKS}"
+
+# If WPGraphQL Content Blocks should be tested against
+if [[ 'true' = "${WPGRAPHQL_CONTENT_BLOCKS}" ]]; then
+
+	WPGRAPHQL_CONTENT_BLOCKS_PLUGIN_SLUG='wp-graphql-content-blocks/wp-graphql-content-blocks.php';
+
+	if [[ -z ${WPGRAPHQL_CONTENT_BLOCKS_VERSION} || "${WPGRAPHQL_CONTENT_BLOCKS_VERSION}" == "latest" ]]; then
+	  # Get latest release version of WPGraphQL Content Blocks
+	  echo "Getting the latest version of WPGraphQL Content Blocks"
+	  WPGRAPHQL_CONTENT_BLOCKS_VERSION=$(curl --location --request GET "https://api.github.com/repos/wpengine/wp-graphql-content-blocks/releases/latest" | jq '.tag_name' | tr -d '"' )
+	fi
+
+	echo "Installing WPGraphQL Content Blocks ${WPGRAPHQL_CONTENT_BLOCKS_VERSION}"
+    wp plugin install "https://github.com/wpengine/wp-graphql-content-blocks/releases/download/${WPGRAPHQL_CONTENT_BLOCKS_VERSION}/wp-graphql-content-blocks.zip" --allow-root --activate
+
+## If WPGRAPHQL_CONTENT_BLOCKS is not true, skip installing it
+else
+	echo "Skipping installing WPGraphQL Content Blocks"
+	WPGRAPHQL_CONTENT_BLOCKS_PLUGIN_SLUG='wp-graphql-content-blocks/wp-graphql-content-blocks.php';
+fi
 
 ## List the plugins that were activated to ensure ACF Free or Pro was properly activated
 wp plugin list --allow-root


### PR DESCRIPTION
What does this implement/fix? Explain your changes.
---------------------------------------------------
This (attempts to) fix the test suites so they can properly test queries with ACF Blocks + WPGraphQL Content Blocks

Does this close any currently open issues?
------------------------------------------
closes #92

Any other comments?
-------------------
I'm able to run the tests locally, but they fail in Github, so this could take some trial/error. 

I _think_ the issue might be related to .env vars and how they pass through the system(s), but not 💯 sure right now.

The expectation is that we should see all WPUnit tests pass. 

Any test that tests against `WPGRAPHQL_CONTENT_BLOCKS=true` should include the `Field on acf block` test, and the other tests should mark it as incomplete. 