### PR TITLE
fix: repeater and group fields on ACF Blocks

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -28,13 +28,13 @@
     "szepeviktor/phpstan-wordpress": "~1.3.0",
     "codeception/module-rest": "^1.4",
     "wp-graphql/wp-graphql-testcase": "~2.3",
-    "wp-graphql/wp-graphql": "^1.14",
     "phpunit/phpunit": "^9.5",
     "slevomat/coding-standard": "^8.9",
     "simpod/php-coveralls-mirror": "^3.0",
     "phpstan/extension-installer": "^1.3",
     "php-stubs/acf-pro-stubs": "6.*",
-    "wp-cli/wp-cli-bundle": "^2.8"
+    "wp-cli/wp-cli-bundle": "^2.8",
+    "axepress/wp-graphql-stubs": "^1.16"
   },
   "config": {
     "platform": {

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "db09db795e539ebc96fce620fd2f2452",
+    "content-hash": "5955564ec944fe8a758a90b2d1f42df0",
     "packages": [
         {
             "name": "appsero/client",
@@ -154,6 +154,58 @@
                 "wiki": "https://github.com/Automattic/VIP-Coding-Standards/wiki"
             },
             "time": "2023-08-24T15:11:13+00:00"
+        },
+        {
+            "name": "axepress/wp-graphql-stubs",
+            "version": "v1.16.0+repack.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/AxeWP/wp-graphql-stubs.git",
+                "reference": "47ce4c7e0c715bea84bc84b675e274b94a8c22f4"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/AxeWP/wp-graphql-stubs/zipball/47ce4c7e0c715bea84bc84b675e274b94a8c22f4",
+                "reference": "47ce4c7e0c715bea84bc84b675e274b94a8c22f4",
+                "shasum": ""
+            },
+            "require": {
+                "php-stubs/wordpress-stubs": "^5.4 || ^6.0"
+            },
+            "require-dev": {
+                "php": ">=7.3",
+                "php-stubs/generator": "^0.8.0",
+                "phpstan/phpstan": "^1.8"
+            },
+            "suggest": {
+                "szepeviktor/phpstan-wordpress": "WordPress extensions for PHPStan"
+            },
+            "type": "library",
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "description": "WPGraphQL function and class declaration stubs for static analysis.",
+            "homepage": "https://github.com/axewp/wp-graphql-stubs",
+            "keywords": [
+                "PHPStan",
+                "graphql",
+                "static analysis",
+                "wordpress",
+                "wp-graphql",
+                "wpgraphql"
+            ],
+            "support": {
+                "issues": "https://github.com/AxeWP/wp-graphql-stubs/issues",
+                "source": "https://github.com/AxeWP/wp-graphql-stubs/tree/v1.16.0+repack.1"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/AxeWp",
+                    "type": "github"
+                }
+            ],
+            "time": "2023-10-01T17:13:28+00:00"
         },
         {
             "name": "behat/gherkin",
@@ -2537,51 +2589,6 @@
             "time": "2022-09-21T21:30:03+00:00"
         },
         {
-            "name": "ivome/graphql-relay-php",
-            "version": "v0.6.0",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/ivome/graphql-relay-php.git",
-                "reference": "7055fd45b7e552cee4d1290849b84294b0049373"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/ivome/graphql-relay-php/zipball/7055fd45b7e552cee4d1290849b84294b0049373",
-                "reference": "7055fd45b7e552cee4d1290849b84294b0049373",
-                "shasum": ""
-            },
-            "require": {
-                "php": "^7.1 || ^8.0",
-                "webonyx/graphql-php": "^14.0"
-            },
-            "require-dev": {
-                "phpunit/phpunit": "^7.5 || ^8.5 || ^9.5",
-                "satooshi/php-coveralls": "~1.0"
-            },
-            "type": "library",
-            "autoload": {
-                "classmap": [
-                    "src/"
-                ]
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "BSD-3-Clause"
-            ],
-            "description": "A PHP port of GraphQL Relay reference implementation",
-            "homepage": "https://github.com/ivome/graphql-relay-php",
-            "keywords": [
-                "Relay",
-                "api",
-                "graphql"
-            ],
-            "support": {
-                "issues": "https://github.com/ivome/graphql-relay-php/issues",
-                "source": "https://github.com/ivome/graphql-relay-php/tree/v0.6.0"
-            },
-            "time": "2021-04-24T19:31:29+00:00"
-        },
-        {
             "name": "justinrainbow/json-schema",
             "version": "v5.2.13",
             "source": {
@@ -3761,16 +3768,16 @@
         },
         {
             "name": "phpstan/phpstan",
-            "version": "1.10.37",
+            "version": "1.10.38",
             "source": {
                 "type": "git",
                 "url": "https://github.com/phpstan/phpstan.git",
-                "reference": "058ba07e92f744d4dcf6061ae75283d0c6456f2e"
+                "reference": "5302bb402c57f00fb3c2c015bac86e0827e4b691"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpstan/phpstan/zipball/058ba07e92f744d4dcf6061ae75283d0c6456f2e",
-                "reference": "058ba07e92f744d4dcf6061ae75283d0c6456f2e",
+                "url": "https://api.github.com/repos/phpstan/phpstan/zipball/5302bb402c57f00fb3c2c015bac86e0827e4b691",
+                "reference": "5302bb402c57f00fb3c2c015bac86e0827e4b691",
                 "shasum": ""
             },
             "require": {
@@ -3819,7 +3826,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2023-10-02T16:18:37+00:00"
+            "time": "2023-10-06T14:19:14+00:00"
         },
         {
             "name": "phpunit/php-code-coverage",
@@ -8334,71 +8341,6 @@
             "time": "2016-09-17T22:03:11+00:00"
         },
         {
-            "name": "webonyx/graphql-php",
-            "version": "v14.11.10",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/webonyx/graphql-php.git",
-                "reference": "d9c2fdebc6aa01d831bc2969da00e8588cffef19"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/webonyx/graphql-php/zipball/d9c2fdebc6aa01d831bc2969da00e8588cffef19",
-                "reference": "d9c2fdebc6aa01d831bc2969da00e8588cffef19",
-                "shasum": ""
-            },
-            "require": {
-                "ext-json": "*",
-                "ext-mbstring": "*",
-                "php": "^7.1 || ^8"
-            },
-            "require-dev": {
-                "amphp/amp": "^2.3",
-                "doctrine/coding-standard": "^6.0",
-                "nyholm/psr7": "^1.2",
-                "phpbench/phpbench": "^1.2",
-                "phpstan/extension-installer": "^1.0",
-                "phpstan/phpstan": "0.12.82",
-                "phpstan/phpstan-phpunit": "0.12.18",
-                "phpstan/phpstan-strict-rules": "0.12.9",
-                "phpunit/phpunit": "^7.2 || ^8.5",
-                "psr/http-message": "^1.0",
-                "react/promise": "2.*",
-                "simpod/php-coveralls-mirror": "^3.0"
-            },
-            "suggest": {
-                "psr/http-message": "To use standard GraphQL server",
-                "react/promise": "To leverage async resolving on React PHP platform"
-            },
-            "type": "library",
-            "autoload": {
-                "psr-4": {
-                    "GraphQL\\": "src/"
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "description": "A PHP port of GraphQL reference implementation",
-            "homepage": "https://github.com/webonyx/graphql-php",
-            "keywords": [
-                "api",
-                "graphql"
-            ],
-            "support": {
-                "issues": "https://github.com/webonyx/graphql-php/issues",
-                "source": "https://github.com/webonyx/graphql-php/tree/v14.11.10"
-            },
-            "funding": [
-                {
-                    "url": "https://opencollective.com/webonyx-graphql-php",
-                    "type": "open_collective"
-                }
-            ],
-            "time": "2023-07-05T14:23:37+00:00"
-        },
-        {
             "name": "wp-cli/cache-command",
             "version": "v2.1.1",
             "source": {
@@ -10560,87 +10502,6 @@
                 "wiki": "https://github.com/WordPress/WordPress-Coding-Standards/wiki"
             },
             "time": "2020-05-13T23:57:56+00:00"
-        },
-        {
-            "name": "wp-graphql/wp-graphql",
-            "version": "v1.16.0",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/wp-graphql/wp-graphql.git",
-                "reference": "93429098ed8f661cb7455873518e9303264b4f10"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/wp-graphql/wp-graphql/zipball/93429098ed8f661cb7455873518e9303264b4f10",
-                "reference": "93429098ed8f661cb7455873518e9303264b4f10",
-                "shasum": ""
-            },
-            "require": {
-                "appsero/client": "1.2.1",
-                "ivome/graphql-relay-php": "0.6.0",
-                "php": "^7.1 || ^8.0",
-                "webonyx/graphql-php": "14.11.10"
-            },
-            "require-dev": {
-                "automattic/vipwpcs": "^2.2",
-                "codeception/module-asserts": "^1.0",
-                "codeception/module-cli": "^1.0",
-                "codeception/module-db": "^1.0",
-                "codeception/module-filesystem": "^1.0",
-                "codeception/module-phpbrowser": "^1.0",
-                "codeception/module-rest": "^1.2",
-                "codeception/module-webdriver": "^1.0",
-                "codeception/util-universalframework": "^1.0",
-                "lucatume/wp-browser": "^3.1.6",
-                "phpcompatibility/phpcompatibility-wp": "^2.1",
-                "phpstan/extension-installer": "^1.1",
-                "phpstan/phpstan": "~1.10.18",
-                "phpunit/phpunit": "^9.5",
-                "simpod/php-coveralls-mirror": "^3.0",
-                "slevomat/coding-standard": "^8.9",
-                "szepeviktor/phpstan-wordpress": "~1.3.0",
-                "wp-cli/wp-cli-bundle": "^2.8",
-                "wp-graphql/wp-graphql-testcase": "~2.3"
-            },
-            "type": "wordpress-plugin",
-            "autoload": {
-                "files": [
-                    "access-functions.php",
-                    "activation.php",
-                    "deactivation.php"
-                ],
-                "psr-4": {
-                    "WPGraphQL\\": "src/"
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "GPL-3.0-or-later"
-            ],
-            "authors": [
-                {
-                    "name": "Jason Bahl",
-                    "email": "jasonbahl@mac.com"
-                },
-                {
-                    "name": "Edwin Cromley"
-                },
-                {
-                    "name": "Ryan Kanner"
-                },
-                {
-                    "name": "Hughie Devore"
-                },
-                {
-                    "name": "Chris Zarate"
-                }
-            ],
-            "description": "GraphQL API for WordPress",
-            "support": {
-                "issues": "https://github.com/wp-graphql/wp-graphql/issues",
-                "source": "https://github.com/wp-graphql/wp-graphql/tree/v1.16.0"
-            },
-            "time": "2023-08-31T21:46:33+00:00"
         },
         {
             "name": "wp-graphql/wp-graphql-testcase",

--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -21,6 +21,8 @@ parameters:
         - activation.php
         - deactivation.php
         - src/
+    scanFiles:
+        - vendor/axepress/wp-graphql-stubs/wp-graphql-stubs.php
     excludePaths:
       analyseAndScan:
         - */node_modules/*

--- a/src/FieldType/File.php
+++ b/src/FieldType/File.php
@@ -39,6 +39,14 @@ class File {
 							'resolve'               => static function ( $root, $args, AppContext $context, ResolveInfo $info ) use ( $field_config ) {
 								$value = $field_config->resolve_field( $root, $args, $context, $info );
 
+								if ( is_object( $value ) && isset( $value->ID ) ) {
+									$value = $value->ID;
+								}
+
+								if ( is_array( $value ) && isset( $value['ID'] ) ) {
+									$value = $value['ID'];
+								}
+
 								if ( empty( $value ) || ! absint( $value ) ) {
 									return null;
 								}

--- a/src/FieldType/Gallery.php
+++ b/src/FieldType/Gallery.php
@@ -37,17 +37,22 @@ class Gallery {
 							'resolve'               => static function ( $root, $args, AppContext $context, $info ) use ( $field_config ) {
 								$value = $field_config->resolve_field( $root, $args, $context, $info );
 
+								$value = array_filter( $value );
 
-								if ( empty( $value ) || ! is_array( $value ) ) {
-									return null;
+								if ( empty( $value ) ) {
+									$field_name = $field_config->get_acf_field()['name'] ?? null;
+
+									if ( ! empty( $root[ $field_name ] ) ) {
+										$value = wp_list_pluck( $root[ $field_name ], 'ID' );
+									}
 								}
 
-								$value = array_map(
+								$value = is_array( $value ) ? array_map(
 									static function ( $id ) {
 										return absint( $id );
 									},
 									$value
-								);
+								) : $value;
 
 								$resolver = new PostObjectConnectionResolver( $root, $args, $context, $info, 'attachment' );
 								return $resolver

--- a/src/FieldType/Group.php
+++ b/src/FieldType/Group.php
@@ -1,6 +1,7 @@
 <?php
 namespace WPGraphQL\Acf\FieldType;
 
+use WPGraphQL\AppContext;
 use WPGraphQL\Utils\Utils;
 use WPGraphQL\Acf\AcfGraphQLFieldType;
 use WPGraphQL\Acf\FieldConfig;
@@ -23,6 +24,7 @@ class Group {
 
 					$sub_field_group['graphql_type_name']  = $type_name;
 					$sub_field_group['graphql_field_name'] = $type_name;
+					$sub_field_group['parent']             = $sub_field_group['key'];
 
 					$field_config->get_registry()->register_acf_field_groups_to_graphql(
 						[
@@ -31,6 +33,18 @@ class Group {
 					);
 
 					return $type_name;
+				},
+				'resolve'      => static function ( $root, $args, AppContext $context, $info, $field_type, FieldConfig $field_config ) {
+					$value = $field_config->resolve_field( $root, $args, $context, $info );
+
+					if ( ! empty( $value ) ) {
+						return $value;
+					}
+
+					$root['value']           = $value;
+					$root['acf_field_group'] = $field_config->get_acf_field();
+
+					return $root;
 				},
 			]
 		);

--- a/src/FieldType/Image.php
+++ b/src/FieldType/Image.php
@@ -38,6 +38,14 @@ class Image {
 							'resolve'               => static function ( $root, $args, AppContext $context, ResolveInfo $info ) use ( $field_config ) {
 								$value = $field_config->resolve_field( $root, $args, $context, $info );
 
+								if ( is_object( $value ) && isset( $value->ID ) ) {
+									$value = $value->ID;
+								}
+
+								if ( is_array( $value ) && isset( $value['ID'] ) ) {
+									$value = $value['ID'];
+								}
+
 								if ( empty( $value ) || ! absint( $value ) ) {
 									return null;
 								}
@@ -54,7 +62,7 @@ class Image {
 
 					return 'connection';
 				},
-			] 
+			]
 		);
 	}
 

--- a/src/Registry.php
+++ b/src/Registry.php
@@ -37,7 +37,6 @@ class Registry {
 		if ( $type_registry instanceof TypeRegistry ) {
 			$this->type_registry = $type_registry;
 		} else {
-			// @phpstan-ignore-next-line
 			$this->type_registry = \WPGraphQL::get_type_registry();
 		}
 

--- a/src/WPGraphQLAcf.php
+++ b/src/WPGraphQLAcf.php
@@ -122,7 +122,7 @@ class WPGraphQLAcf {
 		}
 
 		// Have we met the minimum version requirement?
-		if ( ! class_exists( 'WPGraphQL' ) || ! defined( 'WPGRAPHQL_VERSION' ) || empty( WPGRAPHQL_VERSION ) || true === version_compare( WPGRAPHQL_VERSION, WPGRAPHQL_FOR_ACF_VERSION_WPGRAPHQL_REQUIRED_MIN_VERSION, 'lt' ) ) {
+		if ( ! class_exists( 'WPGraphQL' ) || ! defined( 'WPGRAPHQL_VERSION' ) || true === version_compare( WPGRAPHQL_VERSION, WPGRAPHQL_FOR_ACF_VERSION_WPGRAPHQL_REQUIRED_MIN_VERSION, 'lt' ) ) {
 			// translators: %s is the version of the plugin
 			$this->plugin_load_error_messages[] = sprintf( __( 'WPGraphQL v%s or higher is required to be installed and active', 'wp-graphql-acf' ), WPGRAPHQL_FOR_ACF_VERSION_WPGRAPHQL_REQUIRED_MIN_VERSION );
 		}

--- a/tests/_support/WPUnit/AcfFieldTestCase.php
+++ b/tests/_support/WPUnit/AcfFieldTestCase.php
@@ -59,9 +59,11 @@ abstract class AcfFieldTestCase extends WPGraphQLAcfTestCase {
 	}
 
 	/**
+	 * @param string $acf_field_key
+	 * @param string $acf_field_name
 	 * @return array
 	 */
-	public function get_extra_block_data_to_store( $acf_field_key ): array {
+	public function get_extra_block_data_to_store( $acf_field_key = '', $acf_field_name = '' ): array {
 			return [];
 	}
 
@@ -302,7 +304,7 @@ abstract class AcfFieldTestCase extends WPGraphQLAcfTestCase {
 			'data' => array_merge( [
 				$this->get_field_name() => $this->get_block_data_to_store(),
 				'_' . $this->get_field_name() => $acf_field_key,
-			], $this->get_extra_block_data_to_store( $acf_field_key ) ),
+			], $this->get_extra_block_data_to_store( $acf_field_key, $this->get_field_name() ) ),
 			'align' => '',
 			'mode' => 'edit'
 		] );
@@ -314,6 +316,8 @@ abstract class AcfFieldTestCase extends WPGraphQLAcfTestCase {
 
 		<!-- wp:acf/test-block '. $encoded_block_data .' /-->
 		';
+
+		codecept_debug( [ 'html_block_content' => $content ]);
 
 
 		$post = $this->factory()->post->create([

--- a/tests/_support/WPUnit/WPGraphQLAcfTestCase.php
+++ b/tests/_support/WPUnit/WPGraphQLAcfTestCase.php
@@ -292,8 +292,9 @@ class WPGraphQLAcfTestCase extends \Tests\WPGraphQL\TestCase\WPGraphQLTestCase {
 	 */
 	public function register_acf_field( array $acf_field = [], array $acf_field_group = [] ): string {
 
+
 		$field_group_key = $this->register_acf_field_group( $acf_field_group );
-		$key = uniqid( 'acf_test',true );
+		$key =  $acf_field['key'] ?? uniqid( 'acf_test',true );
 
 		$config = array_merge( [
 			'parent'            => $field_group_key,

--- a/tests/wpunit/FieldTypes/AcfeDateRangePickerFieldTest.php
+++ b/tests/wpunit/FieldTypes/AcfeDateRangePickerFieldTest.php
@@ -43,7 +43,7 @@ class AcfeDateRangePickerFieldTest extends \Tests\WPGraphQL\Acf\WPUnit\AcfeField
 		return false;
 	}
 
-	public function get_extra_block_data_to_store( $acf_field_key ): array {
+	public function get_extra_block_data_to_store( $acf_field_key = '', $acf_field_name = '' ): array {
 		return [
 			$this->get_field_name() . '_start' => '20230927',
 			'_' . $this->get_field_name() . '_start' => $acf_field_key,

--- a/tests/wpunit/FieldTypes/GroupFieldTest.php
+++ b/tests/wpunit/FieldTypes/GroupFieldTest.php
@@ -10,6 +10,52 @@ class GroupFieldTest extends \Tests\WPGraphQL\Acf\WPUnit\AcfFieldTestCase {
 	}
 
 	/**
+	 * @param array $acf_field
+	 * @param array $acf_field_group
+	 *
+	 * @return string
+	 */
+	public function register_acf_field( array $acf_field = [], array $acf_field_group = [] ): string {
+
+		// set defaults on the acf field
+		// using helper methods from this class.
+		// this allows test cases extending this class
+		// to more easily make use of repeatedly registering
+		// fields of the same type and testing them
+		$acf_field = array_merge( [
+			'name' => $this->get_field_name(),
+			'type' => $this->get_field_type(),
+			'sub_fields' => [
+				[
+					'key' => 'field_64711a0b852e2',
+					'label' => 'Nested Text Field',
+					'name' => 'nested_text_field',
+					'aria-label' => '',
+					'type' => 'text',
+					'instructions' => '',
+					'required' => 0,
+					'conditional_logic' => 0,
+					'wrapper' => array(
+						'width' => '',
+						'class' => '',
+						'id' => '',
+					),
+					'default_value' => '',
+					'maxlength' => '',
+					'placeholder' => '',
+					'prepend' => '',
+					'append' => '',
+					'show_in_graphql' => 1,
+					'graphql_description' => '',
+					'graphql_field_name' => 'nestedTextField',
+				]
+			]
+		], $acf_field );
+
+		return parent::register_acf_field( $acf_field, $acf_field_group );
+	}
+
+	/**
 	 * @return void
 	 */
 	public function tearDown(): void {
@@ -26,6 +72,30 @@ class GroupFieldTest extends \Tests\WPGraphQL\Acf\WPUnit\AcfFieldTestCase {
 
 	public function get_expected_field_resolve_type(): ?string {
 		return 'AcfTestGroupTestGroup';
+	}
+
+	public function get_block_query_fragment() {
+		return '
+		fragment BlockQueryFragment on AcfTestGroup {
+		  testGroup {
+			nestedTextField
+		  }
+		}
+		';
+	}
+
+	public function get_block_data_to_store() {
+		return '';
+	}
+
+	public function get_extra_block_data_to_store( $acf_field_key = '', $acf_field_name = '' ): array {
+		return [ 'test_group_nested_text_field' => 'nested text field value...' ];
+	}
+
+	public function get_expected_block_fragment_response() {
+		return [
+			'nestedTextField' => 'nested text field value...',
+		];
 	}
 
 }

--- a/tests/wpunit/FieldTypes/RepeaterFieldTest.php
+++ b/tests/wpunit/FieldTypes/RepeaterFieldTest.php
@@ -2,10 +2,13 @@
 
 class RepeaterFieldTest extends \Tests\WPGraphQL\Acf\WPUnit\AcfFieldTestCase {
 
+	public $repeater_key;
+
 	/**
 	 * @return void
 	 */
 	public function setUp(): void {
+		$this->repeater_key = uniqid( 'acf_test_repeater',true );
 		parent::setUp();
 	}
 
@@ -21,6 +24,54 @@ class RepeaterFieldTest extends \Tests\WPGraphQL\Acf\WPUnit\AcfFieldTestCase {
 		return 'repeater';
 	}
 
+	/**
+	 * @param array $acf_field
+	 * @param array $acf_field_group
+	 *
+	 * @return string
+	 */
+	public function register_acf_field( array $acf_field = [], array $acf_field_group = [] ): string {
+
+		// set defaults on the acf field
+		// using helper methods from this class.
+		// this allows test cases extending this class
+		// to more easily make use of repeatedly registering
+		// fields of the same type and testing them
+		$acf_field = array_merge( [
+			'name' => $this->get_field_name(),
+			'type' => $this->get_field_type(),
+			'key' => $this->repeater_key,
+			'sub_fields' => [
+				[
+					'key' => 'field_repeater_nested_text_key',
+					'label' => 'Nested Text Field',
+					'name' => 'nested_text_field',
+					'aria-label' => '',
+					'type' => 'text',
+					'instructions' => '',
+					'required' => 0,
+					'conditional_logic' => 0,
+					'wrapper' => array(
+						'width' => '',
+						'class' => '',
+						'id' => '',
+					),
+					'default_value' => '',
+					'maxlength' => '',
+					'placeholder' => '',
+					'prepend' => '',
+					'append' => '',
+					'show_in_graphql' => 1,
+					'graphql_description' => '',
+					'graphql_field_name' => 'nestedTextField',
+					'parent_repeater' => $this->repeater_key,
+				]
+			]
+		], $acf_field );
+
+		return parent::register_acf_field( $acf_field, $acf_field_group );
+	}
+
 	public function get_expected_field_of_type(): ?array {
 		return [
 			'name' => 'AcfTestGroupTestRepeater',
@@ -33,6 +84,35 @@ class RepeaterFieldTest extends \Tests\WPGraphQL\Acf\WPUnit\AcfFieldTestCase {
 
 	public function get_expected_field_resolve_type(): ?string {
 		return null;
+	}
+
+	public function get_block_query_fragment() {
+		return '
+		fragment BlockQueryFragment on AcfTestGroup {
+		  testRepeater {
+			nestedTextField
+		  }
+		}
+		';
+	}
+
+	public function get_block_data_to_store() {
+		return 1;
+	}
+
+	public function get_extra_block_data_to_store( $acf_field_key = '', $acf_field_name = '' ): array {
+		return [
+			'test_repeater_0_nested_text_field' => 'nested text field value...',
+			'_test_repeater_0_nested_text_field' => 'field_repeater_nested_text_key'
+		];
+	}
+
+	public function get_expected_block_fragment_response() {
+		return [
+			[
+				'nestedTextField' => 'nested text field value...',
+			]
+		];
 	}
 
 }


### PR DESCRIPTION
What does this implement/fix? Explain your changes.
---------------------------------------------------

This fixes some resolver issues with Repeater and Group field types when used on ACF Blocks. 



Does this close any currently open issues?
------------------------------------------
fixes #95 


Any relevant logs, error output, GraphiQL screenshots, etc?
-------------------------------------
I have a Group and Repeater field in a field group assigned to an ACF Block. 

The fields show in the Schema and I can query for them: 

### BEFORE

On v2.0.0-beta.5.0.0, the group and repeater fields on a Block were resolving null values:

![CleanShot 2023-10-06 at 13 28 27](https://github.com/wp-graphql/wpgraphql-acf/assets/1260765/52e4e0b2-6491-41fd-a89c-0527abaa6a52)

### AFTER

Now the Group and Repeater fields are resolving as expected

![CleanShot 2023-10-06 at 13 27 06](https://github.com/wp-graphql/wpgraphql-acf/assets/1260765/822735dc-8fa7-4dea-b943-292b77c5ffb9)
