### PR TITLE
release: v2.0.0-beta.5.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Changelog
 
+## 2.0.0-beta.5.1.0
+
+### Chores / Bugfixes
+
+- [#102](https://github.com/wp-graphql/wpgraphql-acf/pull/102): fix: ACF Field Group Location Rules -> GraphQL Schema mapping bugs
+- [#100](https://github.com/wp-graphql/wpgraphql-acf/pull/100): fix: bug with CPTUI Imports, post type/taxonomy graphql_single_name not being respected
+- [#99](https://github.com/wp-graphql/wpgraphql-acf/pull/99): fix: Repeater, Group, File field not resolving properly when used as a field on ACF Blocks
+
+
 ## 2.0.0-beta.5.0.0
 
 [read more](https://github.com/wp-graphql/wpgraphql-acf/releases/tag/v2.0.0-beta.5.0.0)

--- a/wp-graphql-acf.php
+++ b/wp-graphql-acf.php
@@ -4,7 +4,7 @@
  * Description: Re-imagining the WPGraphQL for ACF plugin
  * Author: WPGraphQL, Jason Bahl
  * Author URI: https://www.wpgraphql.com
- * Version: 2.0.0-beta.5.0.1
+ * Version: 2.0.0-beta.5.1.0
  * Text Domain: wp-graphql-acf
  * Requires PHP: 7.3
  * Requires at least: 5.9
@@ -29,7 +29,7 @@ if ( file_exists( __DIR__ . '/vendor/autoload.php' ) ) {
 }
 
 if ( ! defined( 'WPGRAPHQL_FOR_ACF_VERSION' ) ) {
-	define( 'WPGRAPHQL_FOR_ACF_VERSION', '2.0.0-beta.5.0.0' );
+	define( 'WPGRAPHQL_FOR_ACF_VERSION', '2.0.0-beta.5.1.0' );
 }
 
 if ( ! defined( 'WPGRAPHQL_FOR_ACF_VERSION_WPGRAPHQL_REQUIRED_MIN_VERSION' ) ) {


### PR DESCRIPTION
# Release Notes

### Chores / Bugfixes

- [#102](https://github.com/wp-graphql/wpgraphql-acf/pull/102): fix: ACF Field Group Location Rules -> GraphQL Schema mapping bugs
- [#100](https://github.com/wp-graphql/wpgraphql-acf/pull/100): fix: bug with CPTUI Imports, post type/taxonomy graphql_single_name not being respected
- [#99](https://github.com/wp-graphql/wpgraphql-acf/pull/99): fix: Repeater, Group, File field not resolving properly when used as a field on ACF Blocks