### PR TITLE
fix: oembed field type returns embed instead of URL entered to the field

### DIFF
--- a/src/FieldConfig.php
+++ b/src/FieldConfig.php
@@ -286,7 +286,7 @@ class FieldConfig {
 			'select',
 			'wysiwyg',
 			'repeater',
-			'oembed'
+			'oembed',
 		];
 
 		return in_array( $field_type, $types_to_format, true );

--- a/src/FieldConfig.php
+++ b/src/FieldConfig.php
@@ -286,6 +286,7 @@ class FieldConfig {
 			'select',
 			'wysiwyg',
 			'repeater',
+			'oembed'
 		];
 
 		return in_array( $field_type, $types_to_format, true );
@@ -440,7 +441,7 @@ class FieldConfig {
 		 *
 		 * @param mixed $value
 		 * @param array $field_config The ACF Field Config for the field being resolved
-		 * @param mixed $root The Root node or obect of the field being resolved
+		 * @param mixed $root The Root node or object of the field being resolved
 		 * @param mixed $node_id The ID of the node being resolved
 		 */
 		return apply_filters( 'wpgraphql/acf/field_value', $prepared_value, $field_config, $root, $node_id );

--- a/tests/wpunit/FieldTypes/OembedFieldTest.php
+++ b/tests/wpunit/FieldTypes/OembedFieldTest.php
@@ -17,6 +17,10 @@ class OembedFieldTest extends \Tests\WPGraphQL\Acf\WPUnit\AcfFieldTestCase {
 		parent::tearDown();
 	}
 
+	public function get_clone_value_to_save(): string {
+		return 'https://twitter.com/wpgraphql/status/1115652591705190400';
+	}
+
 	public function get_field_type(): string {
 		return 'oembed';
 	}
@@ -31,6 +35,11 @@ class OembedFieldTest extends \Tests\WPGraphQL\Acf\WPUnit\AcfFieldTestCase {
 		  ' . $this->get_formatted_clone_field_name() . '
 		}
 		';
+	}
+
+	public function get_expected_clone_value() {
+		return wp_oembed_get( $this->get_clone_value_to_save(), [ 'width' => 550 ] );
+
 	}
 
 }

--- a/tests/wpunit/PostObjectFieldsTest.php
+++ b/tests/wpunit/PostObjectFieldsTest.php
@@ -544,8 +544,9 @@ class PostObjectFieldsTest extends \Codeception\TestCase\WPTestCase {
 			'name' => 'oembed_field',
 		]);
 
-		$expected = 'https://twitter.com/wpgraphql/status/1115652591705190400';
-		update_field( 'oembed_field', $expected, $this->post_id );
+		$input = 'https://twitter.com/wpgraphql/status/1115652591705190400';
+		update_field( 'oembed_field', $input, $this->post_id );
+		$expected = wp_oembed_get( $input, [ 'width' => 550 ] );
 
 		$query = '
 		query GET_POST_WITH_ACF_FIELD( $postId: Int! ) {


### PR DESCRIPTION
What does this implement/fix? Explain your changes.
---------------------------------------------------

This updates the oEmbed field to return the results of `wp_oembed_get()` instead of returning the raw URL that was input to the field.

Does this close any currently open issues?
------------------------------------------
closes #106 

Any relevant logs, error output, GraphiQL screenshots, etc?
-------------------------------------

### Before:

![CleanShot 2023-10-31 at 08 58 24](https://github.com/wp-graphql/wpgraphql-acf/assets/1260765/3ca5a82f-8223-4dde-bfc8-a8a639c80b65)


### After:

![CleanShot 2023-10-31 at 08 54 32](https://github.com/wp-graphql/wpgraphql-acf/assets/1260765/c5648674-a49f-42a5-a945-b49dc8a7e8e7)

Any other comments?
-------------------
This is probably considered a breaking change to users that were previously getting the raw URL in response and doing something on the client with the url (i.e. fetching the oembed from the source, etc)

If needed, for users negatively impacted by this change, the `graphql_resolve_field` filter can be used to override the resolver for the field(s) to return the previous resolver logic. 
