### PR TITLE
fix: #110 field groups on page templates not resolving

### DIFF
--- a/src/Registry.php
+++ b/src/Registry.php
@@ -645,8 +645,6 @@ class Registry {
 			$fields     = $this->get_fields_for_field_group( $acf_field_group );
 			$interfaces = $this->get_field_group_interfaces( $acf_field_group );
 
-
-
 			// If there's no fields or type name, we can't register the type to the Schema
 			if ( empty( $fields ) || empty( $type_name ) ) {
 				continue;
@@ -733,7 +731,8 @@ class Registry {
 						'kind'            => 'object',
 						'eagerlyLoadType' => empty( $locations ),
 						'name'            => $type_name,
-						'description'     => sprintf( __( 'Added by WPGraphQL for ACF Redux', 'wp-graphql-acf' ), $type_name ),
+						// translators: %s us the name of the ACF Field Group
+						'description'     => sprintf( __( 'The "%s" Field Group. Added to the Schema by "WPGraphQL for ACF".', 'wp-graphql-acf' ), $type_name ),
 						'interfaces'      => [ $type_name . '_Fields' ],
 						'fields'          => $fields,
 						'locations'       => $locations,


### PR DESCRIPTION
What does this implement/fix? Explain your changes.
---------------------------------------------------
This fixes a bug with ACF Field Groups assigned to a Page Template not resolving correctly. 

Does this close any currently open issues?
------------------------------------------
closes #110 


Any relevant logs, error output, GraphiQL screenshots, etc?
-------------------------------------

### Before

The Field Group is queryable on the template, but the fields return `null`

![CleanShot 2023-11-03 at 13 38 16](https://github.com/wp-graphql/wpgraphql-acf/assets/1260765/3d527372-05cc-4b92-9b3b-b1b033382e21)


### After

The Field Group is queryable on the template, and the fields return expected values

![CleanShot 2023-11-03 at 13 37 20](https://github.com/wp-graphql/wpgraphql-acf/assets/1260765/40699baf-ebb8-4405-9cc1-78bc4c19b8c7)

Any other comments?
-------------------

The previous version of the plugin included this filter (see: https://github.com/wp-graphql/wp-graphql-acf/blob/develop/src/class-acf.php#L132-L144), but it wasn't properly ported over.




