### PR TITLE
ci: update tests to run against WordPress 6.4

### DIFF
--- a/.github/workflows/testing-integration.yml
+++ b/.github/workflows/testing-integration.yml
@@ -24,8 +24,8 @@ jobs:
         wpgraphql_content_blocks: [ false ]
         acf_version: [ 5.12.4, 6.1.8 ]
         include:
-          - php: '8.1'
-            wordpress: '6.1'
+          - php: '8.2'
+            wordpress: '6.4.0'
             acf_pro: true
             wpgraphql_content_blocks: true
             coverage: 1


### PR DESCRIPTION
What does this implement/fix? Explain your changes.
---------------------------------------------------

Updates tests to run against WP 6.4

Does this close any currently open issues?
------------------------------------------
closes #121 


