### PR TITLE
release: v2.0.0-beta.6.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,18 @@
 # Changelog
 
+## 2.0.0-beta.6.0.0
+
+### New Features
+
+- [#114](https://github.com/wp-graphql/wpgraphql-acf/pull/114): feat: add pre filter for resolve type
+
+### Chores / Bugfixes
+
+- [#111](https://github.com/wp-graphql/wpgraphql-acf/pull/111): fix: oembed field type returns embed instead of URL entered to the field
+- [#112](https://github.com/wp-graphql/wpgraphql-acf/pull/112): fix: field groups on page templates not resolving
+- [#116](https://github.com/wp-graphql/wpgraphql-acf/pull/116): fix: error when querying `post_object`, `relationship` or `page_link` field nested on a `repeater` or `flexible_content` field
+- [#122](https://github.com/wp-graphql/wpgraphql-acf/pull/122): ci: update tests to run against WordPress 6.4
+
 ## 2.0.0-beta.5.1.0
 
 ### Chores / Bugfixes

--- a/src/FieldType/Relationship.php
+++ b/src/FieldType/Relationship.php
@@ -63,18 +63,20 @@ class Relationship {
 					$ids = $value;
 				}
 
-				$ids = array_filter( array_map(
-					static function ( $id ) {
-						if ( is_object( $id ) && isset( $id->ID ) ) {
-							$id = $id->ID;
-						}
-						// filter out values that are not IDs
-						// this means that external urls or urls to things like
-						// archive links will not resolve.
-						return absint( $id ) ?: null;
-					},
-					$ids
-				) );
+				$ids = array_filter(
+					array_map(
+						static function ( $id ) {
+							if ( is_object( $id ) && isset( $id->ID ) ) {
+								$id = $id->ID;
+							}
+							// filter out values that are not IDs
+							// this means that external urls or urls to things like
+							// archive links will not resolve.
+							return absint( $id ) ?: null;
+						},
+						$ids
+					) 
+				);
 
 				$resolver = new PostObjectConnectionResolver( $root, $args, $context, $info, 'any' );
 

--- a/src/FieldType/Relationship.php
+++ b/src/FieldType/Relationship.php
@@ -63,17 +63,21 @@ class Relationship {
 					$ids = $value;
 				}
 
-				$ids = array_map(
+				$ids = array_filter( array_map(
 					static function ( $id ) {
 						if ( is_object( $id ) && isset( $id->ID ) ) {
 							$id = $id->ID;
 						}
-						return absint( $id );
+						// filter out values that are not IDs
+						// this means that external urls or urls to things like
+						// archive links will not resolve.
+						return absint( $id ) ?: null;
 					},
 					$ids
-				);
+				) );
 
 				$resolver = new PostObjectConnectionResolver( $root, $args, $context, $info, 'any' );
+
 
 				if ( $is_one_to_one ) {
 					$resolver = $resolver->one_to_one();

--- a/wp-graphql-acf.php
+++ b/wp-graphql-acf.php
@@ -4,7 +4,7 @@
  * Description: Re-imagining the WPGraphQL for ACF plugin
  * Author: WPGraphQL, Jason Bahl
  * Author URI: https://www.wpgraphql.com
- * Version: 2.0.0-beta.5.1.0
+ * Version: 2.0.0-beta.6.0.0
  * Text Domain: wp-graphql-acf
  * Requires PHP: 7.3
  * Requires at least: 5.9
@@ -29,7 +29,7 @@ if ( file_exists( __DIR__ . '/vendor/autoload.php' ) ) {
 }
 
 if ( ! defined( 'WPGRAPHQL_FOR_ACF_VERSION' ) ) {
-	define( 'WPGRAPHQL_FOR_ACF_VERSION', '2.0.0-beta.5.1.0' );
+	define( 'WPGRAPHQL_FOR_ACF_VERSION', '2.0.0-beta.6.0.0' );
 }
 
 if ( ! defined( 'WPGRAPHQL_FOR_ACF_VERSION_WPGRAPHQL_REQUIRED_MIN_VERSION' ) ) {


### PR DESCRIPTION
## 2.0.0-beta.6.0.0

### New Features

- [#114](https://github.com/wp-graphql/wpgraphql-acf/pull/114): feat: add pre filter for resolve type

### Chores / Bugfixes

- [#111](https://github.com/wp-graphql/wpgraphql-acf/pull/111): fix: oembed field type returns embed instead of URL entered to the field
- [#112](https://github.com/wp-graphql/wpgraphql-acf/pull/112): fix: field groups on page templates not resolving
- [#116](https://github.com/wp-graphql/wpgraphql-acf/pull/116): fix: error when querying `post_object`, `relationship` or `page_link` field nested on a `repeater` or `flexible_content` field
- [#122](https://github.com/wp-graphql/wpgraphql-acf/pull/122): ci: update tests to run against WordPress 6.4
