### PR TITLE
- make sure oembed field is also formatted when part of a flexible_content field

### DIFF
--- a/src/FieldConfig.php
+++ b/src/FieldConfig.php
@@ -286,6 +286,7 @@ class FieldConfig {
 			'select',
 			'wysiwyg',
 			'repeater',
+			'flexible_content',
 			'oembed',
 		];
 


### PR DESCRIPTION
<!--

### Your checklist for this pull request
Thanks for sending a pull request! Please make sure you click the link above to view the contribution guidelines, then fill out the blanks below.

-->

What does this implement/fix? Explain your changes.
---------------------------------------------------
This change makes sure that fields that are part of a `flexible_content` field are also formatted. Currently this is not the case for the `oembed` field for example.

This should have been part of the fix of https://github.com/wp-graphql/wpgraphql-acf/issues/106


Does this close any currently open issues?
------------------------------------------
<!--
### Write "closes #{pr number}"
### see: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->
No

Any relevant logs, error output, GraphiQL screenshots, etc?
-------------------------------------
### Before 

![image](https://github.com/wp-graphql/wpgraphql-acf/assets/1632377/b402fbca-dc02-4324-b02e-8f5bcc1d7cd2)

### After

![image](https://github.com/wp-graphql/wpgraphql-acf/assets/1632377/edb9da3f-18d5-4b15-bc23-6ec2fbe8eaaf)




Any other comments?
-------------------
This is a breaking change.

