### PR TITLE
feat: replace Appsero Updater.php with blank class to pass .org req's

### DIFF
--- a/build/Updater.php
+++ b/build/Updater.php
@@ -1,0 +1,14 @@
+<?php
+namespace Appsero;
+
+/**
+ * Temp replacement for the Updater.php class
+ * to allow the plugin to pass WordPress.org
+ * review process until Appsero has a formal solution.
+ *
+ * This file is used to replace the Updater.php class in the Appsero vendor dep after
+ * composer install is run, before the plugin is bundled as a .zip
+ *
+ * see: https://github.com/Appsero/client/issues/34
+ */
+class Updater {}

--- a/composer.json
+++ b/composer.json
@@ -73,7 +73,13 @@
     ],
     "build-app": "@docker-build -a",
     "build-test": "@docker-build -t",
-    "build-plugin": "composer install --no-dev && composer run-script zip && composer install",
+    "build-plugin": [
+      "composer install --no-dev",
+      "rm ./vendor/appsero/client/src/Updater.php",
+      "cp ./build/Updater.php ./vendor/appsero/client/src/",
+      "composer run-script zip",
+      "composer install"
+    ],
     "run-app": "@docker-run -a",
     "run-test": "@docker-run -t",
     "lint": "vendor/bin/phpcs",


### PR DESCRIPTION
What does this implement/fix? Explain your changes.
---------------------------------------------------
WordPress.org isn't allowing plugins that include the Appsero Client SDK to be approved for hosting on WordPress.org due to code in the Updater.php class. (see: https://github.com/Appsero/client/issues/34)

This PR gets around that by replacing the Updater.php file with a blank Updater.php class during the plugin-build step

Does this close any currently open issues?
------------------------------------------
closes #129 


Any other comments?
-------------------
Ideally this is a temporary workaround as the Appsero team is working with WordPress.org on a more permanent solution