### PR TITLE
fix: options page with custom post_id not resolving properly

### DIFF
--- a/src/Model/AcfOptionsPage.php
+++ b/src/Model/AcfOptionsPage.php
@@ -53,7 +53,7 @@ class AcfOptionsPage extends Model {
 				'id'        => function () {
 					return Relay::toGlobalId( 'acf_options_page', $this->data['menu_slug'] );
 				},
-				'acfId'     => 'options',
+				'acfId'     => $this->data['post_id'] ?? 'options',
 			];
 		}
 	}

--- a/src/Registry.php
+++ b/src/Registry.php
@@ -356,6 +356,7 @@ class Registry {
 		);
 
 		foreach ( $graphql_options_pages as $graphql_options_page ) {
+			$graphql_options_page['is_options_page'] = true;
 			if ( ! $this->should_field_group_show_in_graphql( $graphql_options_page ) ) {
 				continue;
 			}

--- a/src/Utils.php
+++ b/src/Utils.php
@@ -56,11 +56,11 @@ class Utils {
 				// @phpstan-ignore-next-line
 				$id = 'comment_' . absint( $node->databaseId );
 				break;
-			case is_array( $node ) && isset( $node['post_id'] ) && 'options' === $node['post_id']:
-				$id = $node['post_id'];
-				break;
 			case $node instanceof AcfOptionsPage:
 				$id = $node->acfId;
+				break;
+			case is_array( $node ) && isset( $node['post_id'] ):
+				$id = $node['post_id'];
 				break;
 			default:
 				$id = 0;
@@ -282,7 +282,7 @@ class Utils {
 		// if the field group was configured with no "show_in_graphql" value, default to the "show_in_rest" value
 		// to determine if the group should be available in an API
 		if (
-			( isset( $acf_field_group['post_id'] ) && 'options' !== $acf_field_group['post_id'] ) &&
+			( isset( $acf_field_group['is_options_page'] ) && false === $acf_field_group['is_options_page'] ) &&
 			! isset( $acf_field_group['show_in_graphql'] ) ) {
 			$acf_field_group['show_in_graphql'] = $show_in_rest ?? false;
 		}

--- a/tests/wpunit/OptionsPageTest.php
+++ b/tests/wpunit/OptionsPageTest.php
@@ -203,17 +203,6 @@ class OptionsPageTest extends \Tests\WPGraphQL\Acf\WPUnit\WPGraphQLAcfTestCase {
 
 		$this->assertSame( $expected_value, $get_field );
 
-		$this->registerOptionsPage(
-			[
-				'page_title' => 'CustomGraphqlName',
-				'menu_title' => __( 'Custom GraphQL Name' ),
-				'menu_slug'  => 'custom-graphql-name',
-				'capability' => 'edit_posts',
-				'post_id'   => 'custom-graphql-name',
-				// options pages will show in the Schema unless set to false
-				'graphql_type_name'   => 'MyCustomOptionsName',
-			]
-		);
 
 		$this->register_acf_field( [], [
 			'graphql_field_name' => 'OptionsFields',

--- a/tests/wpunit/OptionsPageTest.php
+++ b/tests/wpunit/OptionsPageTest.php
@@ -189,14 +189,6 @@ class OptionsPageTest extends \Tests\WPGraphQL\Acf\WPUnit\WPGraphQLAcfTestCase {
 			]
 		);
 
-		$expected_value = 'test value';
-
-		// Save a value to the ACF Option Field
-		// see: https://www.advancedcustomfields.com/resources/update_field/#update-a-value-from-different-objects
-		update_field( 'text', $expected_value, 'custom-graphql-name' );
-		$get_field = get_field( 'text', 'custom-graphql-name' );
-
-
 		$this->register_acf_field( [], [
 			'graphql_field_name' => 'OptionsFields',
 			'location' => [
@@ -209,6 +201,14 @@ class OptionsPageTest extends \Tests\WPGraphQL\Acf\WPUnit\WPGraphQLAcfTestCase {
 				],
 			],
 		]);
+
+		$expected_value = 'test value';
+
+		// Save a value to the ACF Option Field
+		// see: https://www.advancedcustomfields.com/resources/update_field/#update-a-value-from-different-objects
+		update_field( 'text', $expected_value, 'custom-graphql-name' );
+		$get_field = get_field( 'text', 'custom-graphql-name' );
+
 
 		$query = '
 		{

--- a/tests/wpunit/OptionsPageTest.php
+++ b/tests/wpunit/OptionsPageTest.php
@@ -196,13 +196,6 @@ class OptionsPageTest extends \Tests\WPGraphQL\Acf\WPUnit\WPGraphQLAcfTestCase {
 		update_field( 'text', $expected_value, 'custom-graphql-name' );
 		$get_field = get_field( 'text', 'custom-graphql-name' );
 
-		codecept_debug( [
-			'$get_field' => $get_field,
-			'$options_pages' => acf_get_options_pages(),
-		]);
-
-		$this->assertSame( $expected_value, $get_field );
-
 
 		$this->register_acf_field( [], [
 			'graphql_field_name' => 'OptionsFields',
@@ -219,8 +212,8 @@ class OptionsPageTest extends \Tests\WPGraphQL\Acf\WPUnit\WPGraphQLAcfTestCase {
 
 		$query = '
 		{
-		  myCustomOptionsName {
-		    optionsFields {
+		  myCustomOptionsName { # this is the name of the options page based on graphql_type_name
+		    optionsFields { # this is the field name for the field group
 		      text
 		    }
 		  }


### PR DESCRIPTION
What does this implement/fix? Explain your changes.
---------------------------------------------------
This fixes a bug where ACF Options Pages that are registered with a custom post_id were not resolving. 

Does this close any currently open issues?
------------------------------------------
closes #128 

Any relevant logs, error output, GraphiQL screenshots, etc?
-------------------------------------

### Before:

![CleanShot 2023-11-28 at 08 37 01](https://github.com/wp-graphql/wpgraphql-acf/assets/1260765/0746c883-06d6-4897-ba38-7499c04ce564)


### After: 

![CleanShot 2023-11-28 at 08 32 44](https://github.com/wp-graphql/wpgraphql-acf/assets/1260765/b2d39841-da19-49eb-b645-4bea99c4a1c4)

