### PR TITLE
Create sync-develop-with-main.yml

### DIFF
--- a/.github/workflows/sync-develop-with-main.yml
+++ b/.github/workflows/sync-develop-with-main.yml
@@ -1,0 +1,26 @@
+name: Keep develop in sync with main
+
+on:
+  push:
+    branches:
+      - main
+
+jobs:
+  merge-main-back-to-develop:
+    timeout-minutes: 2
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          token: ${{ secrets.SYNC_TOKEN }}
+      - name: Set Git config
+        run: |
+          git config --local user.email "actions@github.com"
+          git config --local user.name "Github Actions"
+      - name: Merge main back to develop
+        run: |
+          git fetch --unshallow
+          git checkout develop
+          git pull
+          git merge --no-ff origin/main -m "Auto-merge main back to develop"
+          git push


### PR DESCRIPTION
What does this implement/fix? Explain your changes.
---------------------------------------------------
This keeps "develop" in sync with "main" after releases. 

Based on the core WPGraphQL workflow: https://github.com/wp-graphql/wp-graphql/blob/develop/.github/workflows/sync-develop-with-master.yml