### PR TITLE
release: v2.0.0 beta.7.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,18 @@
 # Changelog
 
+## 2.0.0-beta.7.0.0
+
+### BREAKING CHANGES
+
+- [#136](https://github.com/wp-graphql/wpgraphql-acf/pull/136): fix: clone fields not respecting "prefix_name" setting
+
+### Chores / Bugfixes
+
+- [#126](https://github.com/wp-graphql/wpgraphql-acf/pull/126): fix: Make sure oembed field is also formatted when part of a flexible_content field. Thanks @kpoelhekke!
+- [#131](https://github.com/wp-graphql/wpgraphql-acf/pull/131): ci: replace Appsero Updater.php with a blank class to satisfy WordPress.org reqs.
+- [#132](https://github.com/wp-graphql/wpgraphql-acf/pull/132): fix: options page with custom post_id not resolving properly
+- [#16](https://github.com/wp-graphql/wpgraphql-acf/pull/16): ci: Build the plugin zip, deploy to WordPress.org
+
 ## 2.0.0-beta.6.0.0
 
 ### New Features

--- a/wp-graphql-acf.php
+++ b/wp-graphql-acf.php
@@ -4,7 +4,7 @@
  * Description: Re-imagining the WPGraphQL for ACF plugin
  * Author: WPGraphQL, Jason Bahl
  * Author URI: https://www.wpgraphql.com
- * Version: 2.0.0-beta.6.0.0
+ * Version: 2.0.0-beta.7.0.0
  * Text Domain: wp-graphql-acf
  * Requires PHP: 7.3
  * Requires at least: 5.9
@@ -29,7 +29,7 @@ if ( file_exists( __DIR__ . '/vendor/autoload.php' ) ) {
 }
 
 if ( ! defined( 'WPGRAPHQL_FOR_ACF_VERSION' ) ) {
-	define( 'WPGRAPHQL_FOR_ACF_VERSION', '2.0.0-beta.6.0.0' );
+	define( 'WPGRAPHQL_FOR_ACF_VERSION', '2.0.0-beta.7.0.0' );
 }
 
 if ( ! defined( 'WPGRAPHQL_FOR_ACF_VERSION_WPGRAPHQL_REQUIRED_MIN_VERSION' ) ) {


### PR DESCRIPTION
# Release Notes

## BREAKING CHANGES

- [#136](https://github.com/wp-graphql/wpgraphql-acf/pull/136): fix: clone fields not respecting "prefix_name" setting

## Chores / Bugfixes

- [#126](https://github.com/wp-graphql/wpgraphql-acf/pull/126): fix: Make sure oembed field is also formatted when part of a flexible_content field. Thanks @kpoelhekke!
- [#131](https://github.com/wp-graphql/wpgraphql-acf/pull/131): ci: replace Appsero Updater.php with a blank class to satisfy WordPress.org reqs.
- [#132](https://github.com/wp-graphql/wpgraphql-acf/pull/132): fix: options page with custom post_id not resolving properly
- [#16](https://github.com/wp-graphql/wpgraphql-acf/pull/16): ci: Build the plugin zip, deploy to WordPress.org
