### PR TITLE
fix: #133 taxonomy field on blocks

### DIFF
--- a/src/FieldType/Taxonomy.php
+++ b/src/FieldType/Taxonomy.php
@@ -9,7 +9,6 @@ use WPGraphQL\Data\Connection\TermObjectConnectionResolver;
 class Taxonomy {
 
 	/**
-	 * Register support for the "taxonomy" ACF field type
 	 */
 	public static function register_field_type(): void {
 		register_graphql_acf_field_type(
@@ -26,16 +25,15 @@ class Taxonomy {
 								return null;
 							}
 
-							$values = [];
 							if ( ! is_array( $value ) ) {
-								$values[] = $value;
+								$value[] = $value;
 							}
 
 							$value = array_map(
 								static function ( $id ) {
 									return absint( $id );
 								},
-								$values
+								$value
 							);
 
 							$resolver = new TermObjectConnectionResolver( $root, $args, $context, $info );

--- a/src/FieldType/Taxonomy.php
+++ b/src/FieldType/Taxonomy.php
@@ -26,15 +26,16 @@ class Taxonomy {
 								return null;
 							}
 
+							$values = [];
 							if ( ! is_array( $value ) ) {
-								$value[] = $value;
+								$values[] = $value;
 							}
 
 							$value = array_map(
 								static function ( $id ) {
 									return absint( $id );
 								},
-								$value
+								$values
 							);
 
 							$resolver = new TermObjectConnectionResolver( $root, $args, $context, $info );

--- a/src/FieldType/Taxonomy.php
+++ b/src/FieldType/Taxonomy.php
@@ -9,7 +9,6 @@ use WPGraphQL\Data\Connection\TermObjectConnectionResolver;
 class Taxonomy {
 
 	/**
-	 * Register support for the "taxonomy" ACF field type
 	 */
 	public static function register_field_type(): void {
 		register_graphql_acf_field_type(
@@ -26,29 +25,22 @@ class Taxonomy {
 								return null;
 							}
 
-							$values = [];
 							if ( ! is_array( $value ) ) {
-								$values[] = $value;
-							} else {
-								$values = $value;
+								$value[] = $value;
 							}
 
-							$ids = array_map(
+							$value = array_map(
 								static function ( $id ) {
 									return absint( $id );
 								},
-								$values
+								$value
 							);
-
-							if ( empty( $ids ) ) {
-								return null;
-							}
 
 							$resolver = new TermObjectConnectionResolver( $root, $args, $context, $info );
 							return $resolver
 							// Set the query to include only the IDs passed in from the field
 							// and orderby the ids
-							->set_query_arg( 'include', $ids )
+							->set_query_arg( 'include', $value )
 							->set_query_arg( 'orderby', 'include' )
 							->get_connection();
 						},

--- a/src/FieldType/Taxonomy.php
+++ b/src/FieldType/Taxonomy.php
@@ -9,6 +9,7 @@ use WPGraphQL\Data\Connection\TermObjectConnectionResolver;
 class Taxonomy {
 
 	/**
+	 * Register support for the "taxonomy" ACF field type
 	 */
 	public static function register_field_type(): void {
 		register_graphql_acf_field_type(
@@ -25,22 +26,29 @@ class Taxonomy {
 								return null;
 							}
 
+							$values = [];
 							if ( ! is_array( $value ) ) {
-								$value[] = $value;
+								$values[] = $value;
+							} else {
+								$values = $value;
 							}
 
-							$value = array_map(
+							$ids = array_map(
 								static function ( $id ) {
 									return absint( $id );
 								},
-								$value
+								$values
 							);
+
+							if ( empty( $ids ) ) {
+								return null;
+							}
 
 							$resolver = new TermObjectConnectionResolver( $root, $args, $context, $info );
 							return $resolver
 							// Set the query to include only the IDs passed in from the field
 							// and orderby the ids
-							->set_query_arg( 'include', $value )
+							->set_query_arg( 'include', $ids )
 							->set_query_arg( 'orderby', 'include' )
 							->get_connection();
 						},

--- a/src/FieldType/User.php
+++ b/src/FieldType/User.php
@@ -39,8 +39,9 @@ class User {
 									return null;
 								}
 
+								$values = [];
 								if ( ! is_array( $value ) ) {
-									$value = [ $value ];
+									$values[] = $value;
 								}
 
 								$value = array_map(
@@ -50,9 +51,8 @@ class User {
 										}
 										return absint( $user );
 									},
-									$value
+									$values
 								);
-
 
 								$resolver = new UserConnectionResolver( $root, $args, $context, $info );
 								return $resolver->set_query_arg( 'include', $value )->set_query_arg( 'orderby', 'include' )->get_connection();

--- a/tests/wpunit/FieldTypes/TaxonomyFieldTest.php
+++ b/tests/wpunit/FieldTypes/TaxonomyFieldTest.php
@@ -1,5 +1,7 @@
 <?php
 
+use WPGraphQL\Utils\Utils;
+
 class TaxonomyFieldTest extends \Tests\WPGraphQL\Acf\WPUnit\AcfFieldTestCase {
 
 	/**
@@ -89,5 +91,196 @@ class TaxonomyFieldTest extends \Tests\WPGraphQL\Acf\WPUnit\AcfFieldTestCase {
 				],
 			]
 		];
+	}
+
+	public function testQueryTaxononomyFieldOnBlock() {
+
+		acf_register_block_type([
+			'name' => 'block_with_category_field',
+			'title' => 'Block with Category Field',
+			'post_types' => [ 'post' ],
+		]);
+
+		$field_key = $this->register_acf_field([
+			'type' => 'taxonomy',
+			'name' => 'Category Test',
+			'show_in_graphql' => true,
+			'graphql_field_name' => 'category',
+			'required' => 1,
+			'taxonomy' => 'category',
+			'add_term' => 0,
+			'save_terms' => 0,
+			'load_terms' => 0,
+			'return_format' => 'object',
+			'field_type' => 'select',
+			'multiple' => 0,
+			'bidirectonal' => 0,
+			'bidirectional_target' => [],
+		], [
+			'name' => 'Block Taxonomy Test',
+			'graphql_field_name' => 'BlockTaxonomyTest',
+			'location' => [
+				[
+					[
+						'param' => 'block',
+						'operator' => '==',
+						'value' => 'acf/block-with-category-field',
+					]
+				]
+			],
+			'graphql_types' => [ 'AcfBlockWithCategoryField' ],
+		]);
+
+		$query = '
+		query GetType( $name: String! ) {
+		  __type( name: $name ) {
+		    fields {
+		      name
+		    }
+		    interfaces {
+		      name
+		    }
+		  }
+		}
+		';
+
+		$actual = $this->graphql( [
+			'query' => $query,
+			'variables' => [
+				'name' => 'AcfBlockWithCategoryField',
+			]
+		]);
+
+		codecept_debug( [
+			'$actual' => $actual,
+		]);
+
+		// Assert that the AcfBlock is in the Schema
+		// Assert the field group shows on the block as expected
+		self::assertQuerySuccessful( $actual, [
+			$this->expectedNode( '__type.fields', [
+				'name' => Utils::format_field_name( 'blockTaxonomyTest' ),
+			]),
+			$this->expectedNode( '__type.interfaces', [
+				'name' => 'AcfBlock',
+			]),
+			// Should implement the With${FieldGroup} Interface
+			$this->expectedNode( '__type.interfaces', [
+				'name' => 'WithAcfBlockTaxonomyTest',
+			])
+		]);
+
+		$category_id = self::factory()->category->create([
+			'name' => uniqid( 'Test Category', true ),
+		]);
+
+		codecept_debug( [
+			'$field_key' => $field_key,
+			'$category_id' => $category_id,
+		]);
+
+		$content = '
+		<!-- wp:acf/block-with-category-field {"name":"acf/block-with-category-field","data":{"' . $field_key . '":"' . $category_id . '"},"align":"","mode":"edit"} /-->
+		';
+
+		$post_id = self::factory()->post->create([
+			'post_type' => 'post',
+			'post_status' => 'publish',
+			'post_title' => 'Test Block With Taxonomy Field',
+			'post_content' => $content,
+		]);
+
+		$query = '
+		query GetPostWithBlocks( $postId: ID! ){
+		  post(id:$postId idType:DATABASE_ID) {
+		    id
+		    title
+		    ...Blocks
+		  }
+		}
+
+		fragment Blocks on NodeWithEditorBlocks {
+		  editorBlocks {
+		    __typename
+		    ...on AcfBlockWithCategoryField {
+		      blockTaxonomyTest {
+		        category {
+		          nodes {
+		            __typename
+		            databaseId
+		          }
+		        }
+		      }
+		    }
+		  }
+		}
+		';
+
+		$variables = [
+			'postId' => $post_id,
+		];
+
+		$actual = self::graphql([
+			'query'     => $query,
+			'variables' => $variables,
+		]);
+
+		codecept_debug( [
+			'$actual' => $actual,
+		]);
+
+		self::assertQuerySuccessful( $actual, [
+			$this->expectedNode( 'post.editorBlocks', [
+				// Expect a block with the __typename AcfBlockWithCategoryField
+				$this->expectedField('__typename', 'AcfBlockWithCategoryField' ),
+				$this->expectedNode( 'blockTaxonomyTest.category.nodes', [
+					'__typename' => 'Category',
+					'databaseId' => $category_id,
+				], 0 ),
+			], 0 ),
+		]);
+
+		$category_2_id = self::factory()->category->create([
+			'name' => uniqid( 'Test Category 2', true ),
+		]);
+
+		$content = '
+		<!-- wp:acf/block-with-category-field {"name":"acf/block-with-category-field","data":{"' . $field_key . '":["' . $category_id . '", "' . $category_2_id . '"]},"align":"","mode":"edit"} /-->
+		';
+
+		$post_id = self::factory()->post->create([
+			'post_type' => 'post',
+			'post_status' => 'publish',
+			'post_title' => 'Test Block With Taxonomy Field',
+			'post_content' => $content,
+		]);
+
+		$actual = self::graphql([
+			'query'     => $query,
+			'variables' => $variables,
+		]);
+
+		codecept_debug( [
+			'$actual' => $actual,
+		]);
+
+		self::assertQuerySuccessful( $actual, [
+			$this->expectedNode( 'post.editorBlocks', [
+				// Expect a block with the __typename AcfBlockWithCategoryField
+				$this->expectedField('__typename', 'AcfBlockWithCategoryField' ),
+				$this->expectedNode( 'blockTaxonomyTest.category.nodes', [
+					'__typename' => 'Category',
+					'databaseId' => $category_id,
+				], 0 ),
+				$this->expectedNode( 'blockTaxonomyTest.category.nodes', [
+					'__typename' => 'Category',
+					'databaseId' => $category_2_id,
+				], 0 ),
+			], 0 ),
+		]);
+
+		wp_delete_post( $post_id );
+		wp_delete_term( $category_id, 'category' );
+		wp_delete_term( $category_2_id, 'category' );
 	}
 }

--- a/tests/wpunit/FieldTypes/TaxonomyFieldTest.php
+++ b/tests/wpunit/FieldTypes/TaxonomyFieldTest.php
@@ -95,6 +95,16 @@ class TaxonomyFieldTest extends \Tests\WPGraphQL\Acf\WPUnit\AcfFieldTestCase {
 
 	public function testQueryTaxononomyFieldOnBlock() {
 
+		// if ACF PRO is not active, skip the test
+		if ( ! defined( 'ACF_PRO' ) ) {
+			$this->markTestSkipped( 'ACF Pro is not active so this test will not run.' );
+		}
+
+		// If WPGraphQL Content Blocks couldn't be activated, skip
+		if ( ! defined( 'WPGRAPHQL_CONTENT_BLOCKS_DIR' ) ) {
+			$this->markTestSkipped( 'This test is skipped when WPGraphQL Content Blocks is not active' );
+		}
+		
 		acf_register_block_type([
 			'name' => 'block_with_category_field',
 			'title' => 'Block with Category Field',


### PR DESCRIPTION
What does this implement/fix? Explain your changes.
---------------------------------------------------
This fixes a bug where the "taxonomy" field will return an error when queried if the field is set to not allow multiple selections, but has multiple selections stored. 

This can happen when the field was configured to allow multiple selections, had data saved, then is later changed to be a single select, but the stored data is still multiple values in an array. 

- [x] FAILED TEST: https://github.com/wp-graphql/wpgraphql-acf/actions/runs/7353282668/job/20019062914#step:7:1822
- [x] PASSING TESTS: https://github.com/wp-graphql/wpgraphql-acf/actions/runs/7353345038 



Does this close any currently open issues?
------------------------------------------
Related to #133 


Any other comments?
-------------------

1. Create a "Taxonomy" field on an ACF Field Group assigned to an ACF Block
2. Set the field to "Multi Select"
3. Edit the block using the field, selecting multiple terms

![CleanShot 2023-12-28 at 19 56 55](https://github.com/wp-graphql/wpgraphql-acf/assets/1260765/eb654fb6-13a2-42ef-bc12-3bc4d48dd5c0)


4. Save the content

Here we can see 2 terms are saved: 

![CleanShot 2023-12-28 at 19 57 22](https://github.com/wp-graphql/wpgraphql-acf/assets/1260765/c7441203-5ad9-4d4f-acf7-805e332c70dc)


5. Change the field back to "Select" (to only allow 1 value) but leave the content as-is, with 2 terms stored as the field's value.
6. Query for the field

## BEFORE

There's an error:

![CleanShot 2023-12-28 at 19 53 48](https://github.com/wp-graphql/wpgraphql-acf/assets/1260765/cb84f2af-6cca-4eac-8215-4524218a6831)

## AFTER

No error, but the response only contains 1 item

![CleanShot 2023-12-28 at 19 55 38](https://github.com/wp-graphql/wpgraphql-acf/assets/1260765/a7077b8b-4f4c-4302-b992-c9c53f9bbf1f)

Which matches the UI of the Block now, and if the block is saved again will only save 1 value instead of multiple:
![CleanShot 2023-12-28 at 19 56 13](https://github.com/wp-graphql/wpgraphql-acf/assets/1260765/4e616211-d4f9-45c4-bb93-6e239914970c)
