### PR TITLE
release: v2.1.0

### DIFF
--- a/.github/workflows/sync-develop-with-main.yml
+++ b/.github/workflows/sync-develop-with-main.yml
@@ -1,0 +1,26 @@
+name: Keep develop in sync with main
+
+on:
+  push:
+    branches:
+      - main
+
+jobs:
+  merge-main-back-to-develop:
+    timeout-minutes: 2
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          token: ${{ secrets.SYNC_TOKEN }}
+      - name: Set Git config
+        run: |
+          git config --local user.email "actions@github.com"
+          git config --local user.name "Github Actions"
+      - name: Merge main back to develop
+        run: |
+          git fetch --unshallow
+          git checkout develop
+          git pull
+          git merge --no-ff origin/main -m "Auto-merge main back to develop"
+          git push

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,25 @@
 # Changelog
 
+## 2.1.0
+
+## Upgrade Notice
+
+While fixing some [performance issues](https://github.com/wp-graphql/wpgraphql-acf/pull/152) we had to adjust the fallback logic for mapping ACF Field Groups to the Schema if they do not have "graphql_types" defined.
+
+ACF Field Groups that did not have "graphql_types" defined AND were assigned to Location Rules based on "post_status", "post_format", "post_category" or "post_taxonomy" _might_ not show in the Schema until their "graphql_types" are explicitly defined.
+
+## New Features
+
+- [#156](https://github.com/wp-graphql/wpgraphql-acf/pull/156): feat: Use published ACF values in resolvers for fields associated with posts that use the block editor, since the Block Editor has a bug preventing meta from being saved for previews. Adds a debug message if ACF fields are queried for with "asPreview" on post(s) that use the block editor.
+
+### Chores / Bugfixes
+
+- [#156](https://github.com/wp-graphql/wpgraphql-acf/pull/156): fix: ACF Fields not resolving when querying "asPreview"
+- [#155](https://github.com/wp-graphql/wpgraphql-acf/pull/155): fix: "show_in_graphql" setting not being respected when turned "off"
+- [#152](https://github.com/wp-graphql/wpgraphql-acf/pull/152): fix: performance issues with mapping ACF Field Groups to the Schema
+- [#148](https://github.com/wp-graphql/wpgraphql-acf/pull/148): fix: bug when querying taxonomy field on blocks
+- [#146](https://github.com/wp-graphql/wpgraphql-acf/pull/146): chore: update phpcs to match core WPGraphQL
+
 ## 2.0.0
 
 - [#142](https://github.com/wp-graphql/wpgraphql-acf/pull/142): Update README, versions, plugin assets for deploy to WordPress.org.

--- a/README.md
+++ b/README.md
@@ -1,8 +1,14 @@
 # WPGraphQL for Advanced Custom Fields
 
+![WPGraphQL for ACF plugin banner](/.wordpress-org/banner-1544x500.png)
+
 WPGraphQL for Advanced Custom Fields is a free, open-source WordPress plugin that adds ACF Fields and Field Groups to the WPGraphQL Schema.
 
+The plugin is [now available on WordPress.org!](https://wordpress.org/plugins/wpgraphql-acf/)
+
 Development of this plugin has been made possible by [WP Engine Atlas](https://wpengine.com/atlas)
+
+Learn more at [https://acf.wpgraphql.com](https://acf.wpgraphql.com)
 
 ## Table of Contents
 

--- a/access-functions.php
+++ b/access-functions.php
@@ -1,16 +1,14 @@
 <?php
 
 /**
- * @param string $acf_field_type
- * @param array|callable  $config
- *
- * @return void
+ * @param string                $acf_field_type
+ * @param array<mixed>|callable $config
  */
 function register_graphql_acf_field_type( string $acf_field_type, $config = [] ): void {
 	add_action(
 		'wpgraphql/acf/register_field_types',
 		static function ( \WPGraphQL\Acf\FieldTypeRegistry $registry ) use ( $acf_field_type, $config ) {
 			$registry->register_field_type( $acf_field_type, $config );
-		} 
+		}
 	);
 }

--- a/composer.json
+++ b/composer.json
@@ -14,7 +14,7 @@
     "appsero/client": "1.2.1"
   },
   "require-dev": {
-    "automattic/vipwpcs": "^2.3",
+    "automattic/vipwpcs": "^3.0",
     "lucatume/wp-browser": "3.1.0",
     "codeception/module-asserts": "^1.3",
     "codeception/module-phpbrowser": "^1.0",

--- a/composer.lock
+++ b/composer.lock
@@ -1770,16 +1770,16 @@
         },
         {
             "name": "doctrine/inflector",
-            "version": "2.0.8",
+            "version": "2.0.9",
             "source": {
                 "type": "git",
                 "url": "https://github.com/doctrine/inflector.git",
-                "reference": "f9301a5b2fb1216b2b08f02ba04dc45423db6bff"
+                "reference": "2930cd5ef353871c821d5c43ed030d39ac8cfe65"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/doctrine/inflector/zipball/f9301a5b2fb1216b2b08f02ba04dc45423db6bff",
-                "reference": "f9301a5b2fb1216b2b08f02ba04dc45423db6bff",
+                "url": "https://api.github.com/repos/doctrine/inflector/zipball/2930cd5ef353871c821d5c43ed030d39ac8cfe65",
+                "reference": "2930cd5ef353871c821d5c43ed030d39ac8cfe65",
                 "shasum": ""
             },
             "require": {
@@ -1841,7 +1841,7 @@
             ],
             "support": {
                 "issues": "https://github.com/doctrine/inflector/issues",
-                "source": "https://github.com/doctrine/inflector/tree/2.0.8"
+                "source": "https://github.com/doctrine/inflector/tree/2.0.9"
             },
             "funding": [
                 {
@@ -1857,7 +1857,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2023-06-16T13:40:37+00:00"
+            "time": "2024-01-15T18:05:13+00:00"
         },
         {
             "name": "doctrine/instantiator",
@@ -2831,16 +2831,16 @@
         },
         {
             "name": "mck89/peast",
-            "version": "v1.15.4",
+            "version": "v1.16.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/mck89/peast.git",
-                "reference": "1df4dc28a6b5bb7ab117ab073c1712256e954e18"
+                "reference": "63dee902bd281c792f1dd760b6df268682032ed0"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/mck89/peast/zipball/1df4dc28a6b5bb7ab117ab073c1712256e954e18",
-                "reference": "1df4dc28a6b5bb7ab117ab073c1712256e954e18",
+                "url": "https://api.github.com/repos/mck89/peast/zipball/63dee902bd281c792f1dd760b6df268682032ed0",
+                "reference": "63dee902bd281c792f1dd760b6df268682032ed0",
                 "shasum": ""
             },
             "require": {
@@ -2853,7 +2853,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "1.15.4-dev"
+                    "dev-master": "1.16.0-dev"
                 }
             },
             "autoload": {
@@ -2874,9 +2874,9 @@
             "description": "Peast is PHP library that generates AST for JavaScript code",
             "support": {
                 "issues": "https://github.com/mck89/peast/issues",
-                "source": "https://github.com/mck89/peast/tree/v1.15.4"
+                "source": "https://github.com/mck89/peast/tree/v1.16.0"
             },
-            "time": "2023-08-12T08:29:29+00:00"
+            "time": "2024-01-11T14:36:12+00:00"
         },
         {
             "name": "mikehaertl/php-shellcommand",
@@ -3145,16 +3145,16 @@
         },
         {
             "name": "nesbot/carbon",
-            "version": "2.72.1",
+            "version": "2.72.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/briannesbitt/Carbon.git",
-                "reference": "2b3b3db0a2d0556a177392ff1a3bf5608fa09f78"
+                "reference": "3e7edc41b58d65509baeb0d4a14c8fa41d627130"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/briannesbitt/Carbon/zipball/2b3b3db0a2d0556a177392ff1a3bf5608fa09f78",
-                "reference": "2b3b3db0a2d0556a177392ff1a3bf5608fa09f78",
+                "url": "https://api.github.com/repos/briannesbitt/Carbon/zipball/3e7edc41b58d65509baeb0d4a14c8fa41d627130",
+                "reference": "3e7edc41b58d65509baeb0d4a14c8fa41d627130",
                 "shasum": ""
             },
             "require": {
@@ -3248,7 +3248,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2023-12-08T23:47:49+00:00"
+            "time": "2024-01-19T00:21:53+00:00"
         },
         {
             "name": "nikic/php-parser",
@@ -3794,16 +3794,16 @@
         },
         {
             "name": "phpstan/phpdoc-parser",
-            "version": "1.24.5",
+            "version": "1.25.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/phpstan/phpdoc-parser.git",
-                "reference": "fedf211ff14ec8381c9bf5714e33a7a552dd1acc"
+                "reference": "bd84b629c8de41aa2ae82c067c955e06f1b00240"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpstan/phpdoc-parser/zipball/fedf211ff14ec8381c9bf5714e33a7a552dd1acc",
-                "reference": "fedf211ff14ec8381c9bf5714e33a7a552dd1acc",
+                "url": "https://api.github.com/repos/phpstan/phpdoc-parser/zipball/bd84b629c8de41aa2ae82c067c955e06f1b00240",
+                "reference": "bd84b629c8de41aa2ae82c067c955e06f1b00240",
                 "shasum": ""
             },
             "require": {
@@ -3835,22 +3835,22 @@
             "description": "PHPDoc parser with support for nullable, intersection and generic types",
             "support": {
                 "issues": "https://github.com/phpstan/phpdoc-parser/issues",
-                "source": "https://github.com/phpstan/phpdoc-parser/tree/1.24.5"
+                "source": "https://github.com/phpstan/phpdoc-parser/tree/1.25.0"
             },
-            "time": "2023-12-16T09:33:33+00:00"
+            "time": "2024-01-04T17:06:16+00:00"
         },
         {
             "name": "phpstan/phpstan",
-            "version": "1.10.50",
+            "version": "1.10.56",
             "source": {
                 "type": "git",
                 "url": "https://github.com/phpstan/phpstan.git",
-                "reference": "06a98513ac72c03e8366b5a0cb00750b487032e4"
+                "reference": "27816a01aea996191ee14d010f325434c0ee76fa"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpstan/phpstan/zipball/06a98513ac72c03e8366b5a0cb00750b487032e4",
-                "reference": "06a98513ac72c03e8366b5a0cb00750b487032e4",
+                "url": "https://api.github.com/repos/phpstan/phpstan/zipball/27816a01aea996191ee14d010f325434c0ee76fa",
+                "reference": "27816a01aea996191ee14d010f325434c0ee76fa",
                 "shasum": ""
             },
             "require": {
@@ -3899,27 +3899,27 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2023-12-13T10:59:42+00:00"
+            "time": "2024-01-15T10:43:00+00:00"
         },
         {
             "name": "phpunit/php-code-coverage",
-            "version": "9.2.29",
+            "version": "9.2.30",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/php-code-coverage.git",
-                "reference": "6a3a87ac2bbe33b25042753df8195ba4aa534c76"
+                "reference": "ca2bd87d2f9215904682a9cb9bb37dda98e76089"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/php-code-coverage/zipball/6a3a87ac2bbe33b25042753df8195ba4aa534c76",
-                "reference": "6a3a87ac2bbe33b25042753df8195ba4aa534c76",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-code-coverage/zipball/ca2bd87d2f9215904682a9cb9bb37dda98e76089",
+                "reference": "ca2bd87d2f9215904682a9cb9bb37dda98e76089",
                 "shasum": ""
             },
             "require": {
                 "ext-dom": "*",
                 "ext-libxml": "*",
                 "ext-xmlwriter": "*",
-                "nikic/php-parser": "^4.15",
+                "nikic/php-parser": "^4.18 || ^5.0",
                 "php": ">=7.3",
                 "phpunit/php-file-iterator": "^3.0.3",
                 "phpunit/php-text-template": "^2.0.2",
@@ -3969,7 +3969,7 @@
             "support": {
                 "issues": "https://github.com/sebastianbergmann/php-code-coverage/issues",
                 "security": "https://github.com/sebastianbergmann/php-code-coverage/security/policy",
-                "source": "https://github.com/sebastianbergmann/php-code-coverage/tree/9.2.29"
+                "source": "https://github.com/sebastianbergmann/php-code-coverage/tree/9.2.30"
             },
             "funding": [
                 {
@@ -3977,7 +3977,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2023-09-19T04:57:46+00:00"
+            "time": "2023-12-22T06:47:57+00:00"
         },
         {
             "name": "phpunit/php-file-iterator",
@@ -4222,16 +4222,16 @@
         },
         {
             "name": "phpunit/phpunit",
-            "version": "9.6.15",
+            "version": "9.6.16",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/phpunit.git",
-                "reference": "05017b80304e0eb3f31d90194a563fd53a6021f1"
+                "reference": "3767b2c56ce02d01e3491046f33466a1ae60a37f"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/05017b80304e0eb3f31d90194a563fd53a6021f1",
-                "reference": "05017b80304e0eb3f31d90194a563fd53a6021f1",
+                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/3767b2c56ce02d01e3491046f33466a1ae60a37f",
+                "reference": "3767b2c56ce02d01e3491046f33466a1ae60a37f",
                 "shasum": ""
             },
             "require": {
@@ -4305,7 +4305,7 @@
             "support": {
                 "issues": "https://github.com/sebastianbergmann/phpunit/issues",
                 "security": "https://github.com/sebastianbergmann/phpunit/security/policy",
-                "source": "https://github.com/sebastianbergmann/phpunit/tree/9.6.15"
+                "source": "https://github.com/sebastianbergmann/phpunit/tree/9.6.16"
             },
             "funding": [
                 {
@@ -4321,7 +4321,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2023-12-01T16:55:19+00:00"
+            "time": "2024-01-19T07:03:14+00:00"
         },
         {
             "name": "psr/clock",
@@ -4982,20 +4982,20 @@
         },
         {
             "name": "sebastian/complexity",
-            "version": "2.0.2",
+            "version": "2.0.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/complexity.git",
-                "reference": "739b35e53379900cc9ac327b2147867b8b6efd88"
+                "reference": "25f207c40d62b8b7aa32f5ab026c53561964053a"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/complexity/zipball/739b35e53379900cc9ac327b2147867b8b6efd88",
-                "reference": "739b35e53379900cc9ac327b2147867b8b6efd88",
+                "url": "https://api.github.com/repos/sebastianbergmann/complexity/zipball/25f207c40d62b8b7aa32f5ab026c53561964053a",
+                "reference": "25f207c40d62b8b7aa32f5ab026c53561964053a",
                 "shasum": ""
             },
             "require": {
-                "nikic/php-parser": "^4.7",
+                "nikic/php-parser": "^4.18 || ^5.0",
                 "php": ">=7.3"
             },
             "require-dev": {
@@ -5027,7 +5027,7 @@
             "homepage": "https://github.com/sebastianbergmann/complexity",
             "support": {
                 "issues": "https://github.com/sebastianbergmann/complexity/issues",
-                "source": "https://github.com/sebastianbergmann/complexity/tree/2.0.2"
+                "source": "https://github.com/sebastianbergmann/complexity/tree/2.0.3"
             },
             "funding": [
                 {
@@ -5035,7 +5035,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2020-10-26T15:52:27+00:00"
+            "time": "2023-12-22T06:19:30+00:00"
         },
         {
             "name": "sebastian/diff",
@@ -5309,20 +5309,20 @@
         },
         {
             "name": "sebastian/lines-of-code",
-            "version": "1.0.3",
+            "version": "1.0.4",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/lines-of-code.git",
-                "reference": "c1c2e997aa3146983ed888ad08b15470a2e22ecc"
+                "reference": "e1e4a170560925c26d424b6a03aed157e7dcc5c5"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/lines-of-code/zipball/c1c2e997aa3146983ed888ad08b15470a2e22ecc",
-                "reference": "c1c2e997aa3146983ed888ad08b15470a2e22ecc",
+                "url": "https://api.github.com/repos/sebastianbergmann/lines-of-code/zipball/e1e4a170560925c26d424b6a03aed157e7dcc5c5",
+                "reference": "e1e4a170560925c26d424b6a03aed157e7dcc5c5",
                 "shasum": ""
             },
             "require": {
-                "nikic/php-parser": "^4.6",
+                "nikic/php-parser": "^4.18 || ^5.0",
                 "php": ">=7.3"
             },
             "require-dev": {
@@ -5354,7 +5354,7 @@
             "homepage": "https://github.com/sebastianbergmann/lines-of-code",
             "support": {
                 "issues": "https://github.com/sebastianbergmann/lines-of-code/issues",
-                "source": "https://github.com/sebastianbergmann/lines-of-code/tree/1.0.3"
+                "source": "https://github.com/sebastianbergmann/lines-of-code/tree/1.0.4"
             },
             "funding": [
                 {
@@ -5362,7 +5362,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2020-11-28T06:42:11+00:00"
+            "time": "2023-12-22T06:20:34+00:00"
         },
         {
             "name": "sebastian/object-enumerator",
@@ -6096,16 +6096,16 @@
         },
         {
             "name": "squizlabs/php_codesniffer",
-            "version": "3.8.0",
+            "version": "3.8.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/PHPCSStandards/PHP_CodeSniffer.git",
-                "reference": "5805f7a4e4958dbb5e944ef1e6edae0a303765e7"
+                "reference": "14f5fff1e64118595db5408e946f3a22c75807f7"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/PHPCSStandards/PHP_CodeSniffer/zipball/5805f7a4e4958dbb5e944ef1e6edae0a303765e7",
-                "reference": "5805f7a4e4958dbb5e944ef1e6edae0a303765e7",
+                "url": "https://api.github.com/repos/PHPCSStandards/PHP_CodeSniffer/zipball/14f5fff1e64118595db5408e946f3a22c75807f7",
+                "reference": "14f5fff1e64118595db5408e946f3a22c75807f7",
                 "shasum": ""
             },
             "require": {
@@ -6115,11 +6115,11 @@
                 "php": ">=5.4.0"
             },
             "require-dev": {
-                "phpunit/phpunit": "^4.0 || ^5.0 || ^6.0 || ^7.0 || ^8.0 || ^9.0"
+                "phpunit/phpunit": "^4.0 || ^5.0 || ^6.0 || ^7.0 || ^8.0 || ^9.3.4"
             },
             "bin": [
-                "bin/phpcs",
-                "bin/phpcbf"
+                "bin/phpcbf",
+                "bin/phpcs"
             ],
             "type": "library",
             "extra": {
@@ -6172,7 +6172,7 @@
                     "type": "open_collective"
                 }
             ],
-            "time": "2023-12-08T12:32:31+00:00"
+            "time": "2024-01-11T20:47:48+00:00"
         },
         {
             "name": "symfony/browser-kit",
@@ -6327,16 +6327,16 @@
         },
         {
             "name": "symfony/console",
-            "version": "v5.4.32",
+            "version": "v5.4.34",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/console.git",
-                "reference": "c70df1ffaf23a8d340bded3cfab1b86752ad6ed7"
+                "reference": "4b4d8cd118484aa604ec519062113dd87abde18c"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/console/zipball/c70df1ffaf23a8d340bded3cfab1b86752ad6ed7",
-                "reference": "c70df1ffaf23a8d340bded3cfab1b86752ad6ed7",
+                "url": "https://api.github.com/repos/symfony/console/zipball/4b4d8cd118484aa604ec519062113dd87abde18c",
+                "reference": "4b4d8cd118484aa604ec519062113dd87abde18c",
                 "shasum": ""
             },
             "require": {
@@ -6406,7 +6406,7 @@
                 "terminal"
             ],
             "support": {
-                "source": "https://github.com/symfony/console/tree/v5.4.32"
+                "source": "https://github.com/symfony/console/tree/v5.4.34"
             },
             "funding": [
                 {
@@ -6422,7 +6422,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2023-11-18T18:23:04+00:00"
+            "time": "2023-12-08T13:33:03+00:00"
         },
         {
             "name": "symfony/css-selector",
@@ -6634,16 +6634,16 @@
         },
         {
             "name": "symfony/event-dispatcher",
-            "version": "v5.4.26",
+            "version": "v5.4.34",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/event-dispatcher.git",
-                "reference": "5dcc00e03413f05c1e7900090927bb7247cb0aac"
+                "reference": "e3bca343efeb613f843c254e7718ef17c9bdf7a3"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/event-dispatcher/zipball/5dcc00e03413f05c1e7900090927bb7247cb0aac",
-                "reference": "5dcc00e03413f05c1e7900090927bb7247cb0aac",
+                "url": "https://api.github.com/repos/symfony/event-dispatcher/zipball/e3bca343efeb613f843c254e7718ef17c9bdf7a3",
+                "reference": "e3bca343efeb613f843c254e7718ef17c9bdf7a3",
                 "shasum": ""
             },
             "require": {
@@ -6699,7 +6699,7 @@
             "description": "Provides tools that allow your application components to communicate with each other by dispatching events and listening to them",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/event-dispatcher/tree/v5.4.26"
+                "source": "https://github.com/symfony/event-dispatcher/tree/v5.4.34"
             },
             "funding": [
                 {
@@ -6715,7 +6715,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2023-07-06T06:34:20+00:00"
+            "time": "2023-12-27T21:12:56+00:00"
         },
         {
             "name": "symfony/event-dispatcher-contracts",
@@ -7659,16 +7659,16 @@
         },
         {
             "name": "symfony/process",
-            "version": "v5.4.28",
+            "version": "v5.4.34",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/process.git",
-                "reference": "45261e1fccad1b5447a8d7a8e67aa7b4a9798b7b"
+                "reference": "8fa22178dfc368911dbd513b431cd9b06f9afe7a"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/process/zipball/45261e1fccad1b5447a8d7a8e67aa7b4a9798b7b",
-                "reference": "45261e1fccad1b5447a8d7a8e67aa7b4a9798b7b",
+                "url": "https://api.github.com/repos/symfony/process/zipball/8fa22178dfc368911dbd513b431cd9b06f9afe7a",
+                "reference": "8fa22178dfc368911dbd513b431cd9b06f9afe7a",
                 "shasum": ""
             },
             "require": {
@@ -7701,7 +7701,7 @@
             "description": "Executes commands in sub-processes",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/process/tree/v5.4.28"
+                "source": "https://github.com/symfony/process/tree/v5.4.34"
             },
             "funding": [
                 {
@@ -7717,7 +7717,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2023-08-07T10:36:04+00:00"
+            "time": "2023-12-02T08:41:43+00:00"
         },
         {
             "name": "symfony/service-contracts",
@@ -7866,16 +7866,16 @@
         },
         {
             "name": "symfony/string",
-            "version": "v5.4.32",
+            "version": "v5.4.34",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/string.git",
-                "reference": "91bf4453d65d8231688a04376c3a40efe0770f04"
+                "reference": "e3f98bfc7885c957488f443df82d97814a3ce061"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/string/zipball/91bf4453d65d8231688a04376c3a40efe0770f04",
-                "reference": "91bf4453d65d8231688a04376c3a40efe0770f04",
+                "url": "https://api.github.com/repos/symfony/string/zipball/e3f98bfc7885c957488f443df82d97814a3ce061",
+                "reference": "e3f98bfc7885c957488f443df82d97814a3ce061",
                 "shasum": ""
             },
             "require": {
@@ -7932,7 +7932,7 @@
                 "utf8"
             ],
             "support": {
-                "source": "https://github.com/symfony/string/tree/v5.4.32"
+                "source": "https://github.com/symfony/string/tree/v5.4.34"
             },
             "funding": [
                 {
@@ -7948,7 +7948,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2023-11-26T13:43:46+00:00"
+            "time": "2023-12-09T13:20:28+00:00"
         },
         {
             "name": "symfony/translation",
@@ -8575,16 +8575,16 @@
         },
         {
             "name": "wp-cli/config-command",
-            "version": "v2.3.2",
+            "version": "v2.3.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/wp-cli/config-command.git",
-                "reference": "9de6ce3536a2db56ae5264c61b6f1a35e9132e01"
+                "reference": "890b6e3c8fd945dcad2bff4bf565ba6dfb33e35d"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/wp-cli/config-command/zipball/9de6ce3536a2db56ae5264c61b6f1a35e9132e01",
-                "reference": "9de6ce3536a2db56ae5264c61b6f1a35e9132e01",
+                "url": "https://api.github.com/repos/wp-cli/config-command/zipball/890b6e3c8fd945dcad2bff4bf565ba6dfb33e35d",
+                "reference": "890b6e3c8fd945dcad2bff4bf565ba6dfb33e35d",
                 "shasum": ""
             },
             "require": {
@@ -8593,7 +8593,7 @@
             },
             "require-dev": {
                 "wp-cli/db-command": "^1.3 || ^2",
-                "wp-cli/wp-cli-tests": "^4"
+                "wp-cli/wp-cli-tests": "^4.2.8"
             },
             "type": "wp-cli-package",
             "extra": {
@@ -8643,9 +8643,9 @@
             "homepage": "https://github.com/wp-cli/config-command",
             "support": {
                 "issues": "https://github.com/wp-cli/config-command/issues",
-                "source": "https://github.com/wp-cli/config-command/tree/v2.3.2"
+                "source": "https://github.com/wp-cli/config-command/tree/v2.3.3"
             },
-            "time": "2023-10-20T10:15:46+00:00"
+            "time": "2023-12-21T10:01:16+00:00"
         },
         {
             "name": "wp-cli/core-command",
@@ -9262,16 +9262,16 @@
         },
         {
             "name": "wp-cli/extension-command",
-            "version": "v2.1.16",
+            "version": "v2.1.17",
             "source": {
                 "type": "git",
                 "url": "https://github.com/wp-cli/extension-command.git",
-                "reference": "71183254b1e403bc0f9b4a97fab48e284cfe1367"
+                "reference": "955bd947d95ef91da501179c7e561d229ab3cc19"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/wp-cli/extension-command/zipball/71183254b1e403bc0f9b4a97fab48e284cfe1367",
-                "reference": "71183254b1e403bc0f9b4a97fab48e284cfe1367",
+                "url": "https://api.github.com/repos/wp-cli/extension-command/zipball/955bd947d95ef91da501179c7e561d229ab3cc19",
+                "reference": "955bd947d95ef91da501179c7e561d229ab3cc19",
                 "shasum": ""
             },
             "require": {
@@ -9354,9 +9354,9 @@
             "homepage": "https://github.com/wp-cli/extension-command",
             "support": {
                 "issues": "https://github.com/wp-cli/extension-command/issues",
-                "source": "https://github.com/wp-cli/extension-command/tree/v2.1.16"
+                "source": "https://github.com/wp-cli/extension-command/tree/v2.1.17"
             },
-            "time": "2023-11-10T12:24:35+00:00"
+            "time": "2024-01-11T11:03:21+00:00"
         },
         {
             "name": "wp-cli/i18n-command",
@@ -10738,5 +10738,5 @@
     "platform-overrides": {
         "php": "7.3"
     },
-    "plugin-api-version": "2.6.0"
+    "plugin-api-version": "2.3.0"
 }

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "5955564ec944fe8a758a90b2d1f42df0",
+    "content-hash": "791220cfdcfd37db605db1c319f0035e",
     "packages": [
         {
             "name": "appsero/client",
@@ -104,24 +104,25 @@
         },
         {
             "name": "automattic/vipwpcs",
-            "version": "2.3.4",
+            "version": "3.0.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/Automattic/VIP-Coding-Standards.git",
-                "reference": "b8610e3837f49c5f2fcc4b663b6c0a7c9b3509b6"
+                "reference": "1b8960ebff9ea3eb482258a906ece4d1ee1e25fd"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/Automattic/VIP-Coding-Standards/zipball/b8610e3837f49c5f2fcc4b663b6c0a7c9b3509b6",
-                "reference": "b8610e3837f49c5f2fcc4b663b6c0a7c9b3509b6",
+                "url": "https://api.github.com/repos/Automattic/VIP-Coding-Standards/zipball/1b8960ebff9ea3eb482258a906ece4d1ee1e25fd",
+                "reference": "1b8960ebff9ea3eb482258a906ece4d1ee1e25fd",
                 "shasum": ""
             },
             "require": {
-                "dealerdirect/phpcodesniffer-composer-installer": "^0.4.1 || ^0.5 || ^0.6.2 || ^0.7 || ^1.0",
                 "php": ">=5.4",
+                "phpcsstandards/phpcsextra": "^1.1.0",
+                "phpcsstandards/phpcsutils": "^1.0.8",
                 "sirbrillig/phpcs-variable-analysis": "^2.11.17",
-                "squizlabs/php_codesniffer": "^3.7.1",
-                "wp-coding-standards/wpcs": "^2.3"
+                "squizlabs/php_codesniffer": "^3.7.2",
+                "wp-coding-standards/wpcs": "^3.0"
             },
             "require-dev": {
                 "php-parallel-lint/php-console-highlighter": "^1.0.0",
@@ -153,7 +154,7 @@
                 "source": "https://github.com/Automattic/VIP-Coding-Standards",
                 "wiki": "https://github.com/Automattic/VIP-Coding-Standards/wiki"
             },
-            "time": "2023-08-24T15:11:13+00:00"
+            "time": "2023-09-05T11:01:05+00:00"
         },
         {
             "name": "axepress/wp-graphql-stubs",
@@ -3747,6 +3748,172 @@
                 "source": "https://github.com/PHPCompatibility/PHPCompatibilityWP"
             },
             "time": "2022-10-24T09:00:36+00:00"
+        },
+        {
+            "name": "phpcsstandards/phpcsextra",
+            "version": "1.2.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/PHPCSStandards/PHPCSExtra.git",
+                "reference": "11d387c6642b6e4acaf0bd9bf5203b8cca1ec489"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/PHPCSStandards/PHPCSExtra/zipball/11d387c6642b6e4acaf0bd9bf5203b8cca1ec489",
+                "reference": "11d387c6642b6e4acaf0bd9bf5203b8cca1ec489",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.4",
+                "phpcsstandards/phpcsutils": "^1.0.9",
+                "squizlabs/php_codesniffer": "^3.8.0"
+            },
+            "require-dev": {
+                "php-parallel-lint/php-console-highlighter": "^1.0",
+                "php-parallel-lint/php-parallel-lint": "^1.3.2",
+                "phpcsstandards/phpcsdevcs": "^1.1.6",
+                "phpcsstandards/phpcsdevtools": "^1.2.1",
+                "phpunit/phpunit": "^4.5 || ^5.0 || ^6.0 || ^7.0 || ^8.0 || ^9.0"
+            },
+            "type": "phpcodesniffer-standard",
+            "extra": {
+                "branch-alias": {
+                    "dev-stable": "1.x-dev",
+                    "dev-develop": "1.x-dev"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "LGPL-3.0-or-later"
+            ],
+            "authors": [
+                {
+                    "name": "Juliette Reinders Folmer",
+                    "homepage": "https://github.com/jrfnl",
+                    "role": "lead"
+                },
+                {
+                    "name": "Contributors",
+                    "homepage": "https://github.com/PHPCSStandards/PHPCSExtra/graphs/contributors"
+                }
+            ],
+            "description": "A collection of sniffs and standards for use with PHP_CodeSniffer.",
+            "keywords": [
+                "PHP_CodeSniffer",
+                "phpcbf",
+                "phpcodesniffer-standard",
+                "phpcs",
+                "standards",
+                "static analysis"
+            ],
+            "support": {
+                "issues": "https://github.com/PHPCSStandards/PHPCSExtra/issues",
+                "security": "https://github.com/PHPCSStandards/PHPCSExtra/security/policy",
+                "source": "https://github.com/PHPCSStandards/PHPCSExtra"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/PHPCSStandards",
+                    "type": "github"
+                },
+                {
+                    "url": "https://github.com/jrfnl",
+                    "type": "github"
+                },
+                {
+                    "url": "https://opencollective.com/php_codesniffer",
+                    "type": "open_collective"
+                }
+            ],
+            "time": "2023-12-08T16:49:07+00:00"
+        },
+        {
+            "name": "phpcsstandards/phpcsutils",
+            "version": "1.0.9",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/PHPCSStandards/PHPCSUtils.git",
+                "reference": "908247bc65010c7b7541a9551e002db12e9dae70"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/PHPCSStandards/PHPCSUtils/zipball/908247bc65010c7b7541a9551e002db12e9dae70",
+                "reference": "908247bc65010c7b7541a9551e002db12e9dae70",
+                "shasum": ""
+            },
+            "require": {
+                "dealerdirect/phpcodesniffer-composer-installer": "^0.4.1 || ^0.5 || ^0.6.2 || ^0.7 || ^1.0",
+                "php": ">=5.4",
+                "squizlabs/php_codesniffer": "^3.8.0 || 4.0.x-dev@dev"
+            },
+            "require-dev": {
+                "ext-filter": "*",
+                "php-parallel-lint/php-console-highlighter": "^1.0",
+                "php-parallel-lint/php-parallel-lint": "^1.3.2",
+                "phpcsstandards/phpcsdevcs": "^1.1.6",
+                "yoast/phpunit-polyfills": "^1.1.0 || ^2.0.0"
+            },
+            "type": "phpcodesniffer-standard",
+            "extra": {
+                "branch-alias": {
+                    "dev-stable": "1.x-dev",
+                    "dev-develop": "1.x-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "PHPCSUtils/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "LGPL-3.0-or-later"
+            ],
+            "authors": [
+                {
+                    "name": "Juliette Reinders Folmer",
+                    "homepage": "https://github.com/jrfnl",
+                    "role": "lead"
+                },
+                {
+                    "name": "Contributors",
+                    "homepage": "https://github.com/PHPCSStandards/PHPCSUtils/graphs/contributors"
+                }
+            ],
+            "description": "A suite of utility functions for use with PHP_CodeSniffer",
+            "homepage": "https://phpcsutils.com/",
+            "keywords": [
+                "PHP_CodeSniffer",
+                "phpcbf",
+                "phpcodesniffer-standard",
+                "phpcs",
+                "phpcs3",
+                "standards",
+                "static analysis",
+                "tokens",
+                "utility"
+            ],
+            "support": {
+                "docs": "https://phpcsutils.com/",
+                "issues": "https://github.com/PHPCSStandards/PHPCSUtils/issues",
+                "security": "https://github.com/PHPCSStandards/PHPCSUtils/security/policy",
+                "source": "https://github.com/PHPCSStandards/PHPCSUtils"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/PHPCSStandards",
+                    "type": "github"
+                },
+                {
+                    "url": "https://github.com/jrfnl",
+                    "type": "github"
+                },
+                {
+                    "url": "https://opencollective.com/php_codesniffer",
+                    "type": "open_collective"
+                }
+            ],
+            "time": "2023-12-08T14:50:00+00:00"
         },
         {
             "name": "phpstan/extension-installer",
@@ -10553,30 +10720,38 @@
         },
         {
             "name": "wp-coding-standards/wpcs",
-            "version": "2.3.0",
+            "version": "3.0.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/WordPress/WordPress-Coding-Standards.git",
-                "reference": "7da1894633f168fe244afc6de00d141f27517b62"
+                "reference": "b4caf9689f1a0e4a4c632679a44e638c1c67aff1"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/WordPress/WordPress-Coding-Standards/zipball/7da1894633f168fe244afc6de00d141f27517b62",
-                "reference": "7da1894633f168fe244afc6de00d141f27517b62",
+                "url": "https://api.github.com/repos/WordPress/WordPress-Coding-Standards/zipball/b4caf9689f1a0e4a4c632679a44e638c1c67aff1",
+                "reference": "b4caf9689f1a0e4a4c632679a44e638c1c67aff1",
                 "shasum": ""
             },
             "require": {
+                "ext-filter": "*",
+                "ext-libxml": "*",
+                "ext-tokenizer": "*",
+                "ext-xmlreader": "*",
                 "php": ">=5.4",
-                "squizlabs/php_codesniffer": "^3.3.1"
+                "phpcsstandards/phpcsextra": "^1.1.0",
+                "phpcsstandards/phpcsutils": "^1.0.8",
+                "squizlabs/php_codesniffer": "^3.7.2"
             },
             "require-dev": {
-                "dealerdirect/phpcodesniffer-composer-installer": "^0.5 || ^0.6",
+                "php-parallel-lint/php-console-highlighter": "^1.0.0",
+                "php-parallel-lint/php-parallel-lint": "^1.3.2",
                 "phpcompatibility/php-compatibility": "^9.0",
-                "phpcsstandards/phpcsdevtools": "^1.0",
+                "phpcsstandards/phpcsdevtools": "^1.2.0",
                 "phpunit/phpunit": "^4.0 || ^5.0 || ^6.0 || ^7.0"
             },
             "suggest": {
-                "dealerdirect/phpcodesniffer-composer-installer": "^0.6 || This Composer plugin will sort out the PHPCS 'installed_paths' automatically."
+                "ext-iconv": "For improved results",
+                "ext-mbstring": "For improved results"
             },
             "type": "phpcodesniffer-standard",
             "notification-url": "https://packagist.org/downloads/",
@@ -10593,6 +10768,7 @@
             "keywords": [
                 "phpcs",
                 "standards",
+                "static analysis",
                 "wordpress"
             ],
             "support": {
@@ -10600,7 +10776,13 @@
                 "source": "https://github.com/WordPress/WordPress-Coding-Standards",
                 "wiki": "https://github.com/WordPress/WordPress-Coding-Standards/wiki"
             },
-            "time": "2020-05-13T23:57:56+00:00"
+            "funding": [
+                {
+                    "url": "https://opencollective.com/thewpcc/contribute/wp-php-63406",
+                    "type": "custom"
+                }
+            ],
+            "time": "2023-09-14T07:06:09+00:00"
         },
         {
             "name": "wp-graphql/wp-graphql-testcase",

--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -8,6 +8,7 @@
 	<file>./deactivation.php</file>
 	<file>./wpgraphql-acf.php</file>
 	<file>./src</file>
+	<exclude-pattern>./phpstan/*</exclude-pattern>
 	<exclude-pattern>*/**/tests/</exclude-pattern>
 	<exclude-pattern>*/node_modules/*</exclude-pattern>
 	<exclude-pattern>*/vendor/*</exclude-pattern>
@@ -51,7 +52,7 @@
 		Tests for WordPress version compatibility.
 		https://github.com/WordPress-Coding-Standards/WordPress-Coding-Standards/wiki/Customizable-sniff-properties
 	-->
-	<config name="minimum_supported_wp_version" value="5.0"/>
+	<config name="minimum_wp_version" value="5.0"/>
 
 	<!-- Individual rule configuration -->
 	<rule ref="WordPress.WP.I18n">
@@ -66,6 +67,11 @@
 			<property name="blank_line_check" value="true"/>
 		</properties>
 	</rule>
+	<rule ref="Squiz.Commenting.FunctionComment">
+		<properties>
+			<property name="skipIfInheritdoc" value="true" />
+		</properties>
+	</rule>
 
 	<!-- Rules -->
 
@@ -75,23 +81,20 @@
 	<!-- Load WordPress VIP Go standards - for use with projects on the (newer) VIP Go platform. -->
 	<rule ref="WordPress-VIP-Go" />
 
-	<rule ref="Squiz.Functions.MultiLineFunctionDeclaration.SpaceAfterFunction"/>
-
 	<!-- Load WordPress Coding standards -->
 	<rule ref="WordPress">
 		<!-- Definitely should not be added back -->
-		<exclude name="Generic.Arrays.DisallowShortArraySyntax"/>
-		<exclude name="WordPress.CodeAnalysis.AssignmentInCondition.Found"/>
+		<exclude name="Universal.Arrays.DisallowShortArraySyntax"/>
+		<exclude name="Universal.Operators.DisallowShortTernary.Found"/>
 		<exclude name="WordPress.Files.FileName"/>
 		<exclude name="WordPress.NamingConventions.ValidVariableName"/>
-		<exclude name="WordPress.PHP.DisallowShortTernary.Found"/>
+		<exclude name="WordPress.WP.Capabilities.Undetermined" />
 		<exclude name="WordPress.NamingConventions.ValidHookName.UseUnderscores"/>
+
 
 		<!-- This would be a breaking change to fix-->
 		<exclude name="WordPress.NamingConventions.ValidFunctionName.MethodNameInvalid" />
-
-		<!-- Should probably not be added back -->
-		<exclude name="PHPCompatibility.Keywords.ForbiddenNamesAsDeclared.objectFound"/>
+		<exclude name="Generic.CodeAnalysis.UnusedFunctionParameter" />
 	</rule>
 
 	<!-- This defines custom escapting functions, such as ACF escaping functions -->
@@ -111,23 +114,19 @@
 
 	<!-- Tests for inline documentation of code -->
 	<rule ref="WordPress-Docs">
-		<exclude name="Generic.Commenting.DocComment.MissingShort"/>
-
-		<!-- Should be re-enabled -->
-		<exclude name="Squiz.Commenting"/>
-	</rule>
-
-		<!-- Additional commenting sniffs are in WPGraphQL-Docs -->
-	<rule ref="Squiz.Commenting.FunctionComment">
+		<!-- Conflicts with FQCN -->
+		<exclude name="Squiz.Commenting.FunctionComment.IncorrectTypeHint" />
 		<!-- Conflicts with b/c in AbstractConnectionResolver -->
 		<exclude name="Squiz.Commenting.FunctionComment.InvalidNoReturn" />
 
 		<!-- Should probably be added back -->
-		<exclude name="Squiz.Commenting.FunctionComment.ParamCommentFullStop" />
+		<exclude name="Generic.Commenting.DocComment.MissingShort"/>
+		<exclude name="Squiz.Commenting.ClassComment.Missing" />
+		<exclude name="Squiz.Commenting.FileComment.Missing" />
 		<exclude name="Squiz.Commenting.FunctionComment.EmptyThrows" />
-		<properties>
-				<property name="skipIfInheritdoc" value="true" />
-		</properties>
+		<exclude name="Squiz.Commenting.FunctionComment.MissingParamComment" />
+		<exclude name="Squiz.Commenting.FunctionComment.ParamCommentFullStop" />
+		<exclude name="Squiz.Commenting.InlineComment.InvalidEndChar" />
 	</rule>
 
 	<!-- Enforce short array syntax -->
@@ -166,6 +165,11 @@
 	<rule ref="SlevomatCodingStandard.Functions.UnusedInheritedVariablePassedToClosure" />
 	<rule ref="SlevomatCodingStandard.Functions.UselessParameterDefaultValue" />
 
+	<rule ref="SlevomatCodingStandard.Namespaces.AlphabeticallySortedUses">
+		<properties>
+			<property name="caseSensitive" value="true"/>
+		</properties>
+	</rule>
 	<rule ref="SlevomatCodingStandard.Namespaces.FullyQualifiedClassNameInAnnotation"/>
 	<rule ref="SlevomatCodingStandard.Namespaces.UnusedUses" />
 	<rule ref="SlevomatCodingStandard.Namespaces.UseDoesNotStartWithBackslash" />
@@ -173,10 +177,27 @@
 	<rule ref="SlevomatCodingStandard.PHP.OptimizedFunctionsWithoutUnpacking" />
 	<rule ref="SlevomatCodingStandard.PHP.TypeCast" />
 
+	<rule ref="SlevomatCodingStandard.TypeHints">
+		<!-- Array syntax is preferred -->
+		<exclude name="SlevomatCodingStandard.TypeHints.DisallowArrayTypeHintSyntax.DisallowedArrayTypeHintSyntax" />
+		<!-- WP dependencies are too loosely typed to implement these safely. Breaking change. -->
+		<exclude name="SlevomatCodingStandard.TypeHints.DisallowMixedTypeHint.DisallowedMixedTypeHint" />
+		<exclude name="SlevomatCodingStandard.TypeHints.ParameterTypeHint.MissingNativeTypeHint" />
+		<exclude name="SlevomatCodingStandard.TypeHints.PropertyTypeHint.MissingNativeTypeHint" />
+		<exclude name="SlevomatCodingStandard.TypeHints.ReturnTypeHint.MissingNativeTypeHint" />
+		<!-- Depends on Squiz.Commenting.FunctionComment.MissingParamComment -->
+		<exclude name="SlevomatCodingStandard.TypeHints.ParameterTypeHint.UselessAnnotation" />
+
+		<!-- Should probably be added back. -->
+		<exclude name="SlevomatCodingStandard.TypeHints.NullableTypeForNullDefaultValue.NullabilityTypeMissing" />
+		<exclude name="SlevomatCodingStandard.TypeHints.DeclareStrictTypes.DeclareStrictTypesMissing" />
+	</rule>
+
 	<rule ref="SlevomatCodingStandard.Variables.DuplicateAssignmentToVariable" />
 	<rule ref="SlevomatCodingStandard.Variables.UnusedVariable" >
 		<properties>
 			<property name="ignoreUnusedValuesWhenOnlyKeysAreUsedInForeach" value="true" />
 		</properties>
 	</rule>
+	<rule ref="SlevomatCodingStandard.Variables.UselessVariable" />
 </ruleset>

--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@ Tags: GraphQL, ACF, API, NextJS, Faust, Headless, Decoupled, React, Vue, Svelte,
 Requires at least: 6.0
 Tested up to: 6.4
 Requires PHP: 7.4
-Stable Tag: 2.0.0
+Stable Tag: 2.1.0
 License: GPL-3
 License URI: https://www.gnu.org/licenses/gpl-3.0.html
 
@@ -104,11 +104,21 @@ Learn more about how [Appsero collects and uses data](https://appsero.com/privac
 
 == Upgrade Notice ==
 
+= 2.1.0 =
+
+While fixing some [performance issues](https://github.com/wp-graphql/wpgraphql-acf/pull/152) we had to adjust the fallback logic for mapping ACF Field Groups to the Schema if they do not have "graphql_types" defined.
+
+ACF Field Groups that did not have "graphql_types" defined AND were assigned to Location Rules based on "post_status", "post_format", "post_category" or "post_taxonomy" _might_ not show in the Schema until their "graphql_types" are explicitly defined.
+
 = 2.0.0 =
 
 This release is a complete re-architecture of WPGraphQL for ACF, introducing breaking changes to the GraphQL Schema and PHP API. Please read the [upgrade guide](https://acf.wpgraphql.com/upgrade-guide/) before upgrading.
 
 == Changelog ==
+
+= 2.1.0 =
+
+
 
 = 2.0.0 =
 

--- a/readme.txt
+++ b/readme.txt
@@ -118,7 +118,17 @@ This release is a complete re-architecture of WPGraphQL for ACF, introducing bre
 
 = 2.1.0 =
 
+**New Features**
 
+- [#156](https://github.com/wp-graphql/wpgraphql-acf/pull/156): feat: Use published ACF values in resolvers for fields associated with posts that use the block editor, since the Block Editor has a bug preventing meta from being saved for previews. Adds a debug message if ACF fields are queried for with "asPreview" on post(s) that use the block editor.
+
+**Chores / Bugfixes**
+
+- [#156](https://github.com/wp-graphql/wpgraphql-acf/pull/156): fix: ACF Fields not resolving when querying "asPreview"
+- [#155](https://github.com/wp-graphql/wpgraphql-acf/pull/155): fix: "show_in_graphql" setting not being respected when turned "off"
+- [#152](https://github.com/wp-graphql/wpgraphql-acf/pull/152): fix: performance issues with mapping ACF Field Groups to the Schema
+- [#148](https://github.com/wp-graphql/wpgraphql-acf/pull/148): fix: bug when querying taxonomy field on blocks
+- [#146](https://github.com/wp-graphql/wpgraphql-acf/pull/146): chore: update phpcs to match core WPGraphQL
 
 = 2.0.0 =
 

--- a/src/AcfGraphQLFieldResolver.php
+++ b/src/AcfGraphQLFieldResolver.php
@@ -19,10 +19,9 @@ class AcfGraphQLFieldResolver {
 	}
 
 	/**
-	 * @return \WPGraphQL\Acf\AcfGraphQLFieldType
+	 * Get the AcfGraphQLFieldType definition
 	 */
 	public function get_acf_graphql_field_type(): AcfGraphQLFieldType {
 		return $this->acf_graphql_field_type;
 	}
-
 }

--- a/src/AcfGraphQLFieldType.php
+++ b/src/AcfGraphQLFieldType.php
@@ -2,8 +2,8 @@
 namespace WPGraphQL\Acf;
 
 use GraphQL\Type\Definition\ResolveInfo;
-use WPGraphQL\AppContext;
 use WPGraphQL\Acf\Admin\Settings;
+use WPGraphQL\AppContext;
 
 /**
  * Configures how an ACF Field Type should interact with WPGraphQL
@@ -20,12 +20,12 @@ class AcfGraphQLFieldType {
 	private $acf_field_type;
 
 	/**
-	 * @var array|callable
+	 * @var array<mixed>|callable
 	 */
 	protected $config;
 
 	/**
-	 * @var array
+	 * @var array<mixed>
 	 */
 	protected $admin_fields = [];
 
@@ -35,15 +35,15 @@ class AcfGraphQLFieldType {
 	protected $resolver;
 
 	/**
-	 * @var array
+	 * @var array<mixed>
 	 */
 	protected $excluded_admin_field_settings = [];
 
 	/**
 	 * Constructor.
 	 *
-	 * @param string $acf_field_type The name of the ACF Field Type
-	 * @param array|callable $config The config for how tha ACF Field Type should map to the WPGraphQL Schema and display Admin settings for the field.
+	 * @param string                $acf_field_type The name of the ACF Field Type
+	 * @param array<mixed>|callable $config The config for how tha ACF Field Type should map to the WPGraphQL Schema and display Admin settings for the field.
 	 */
 	public function __construct( string $acf_field_type, $config = [] ) {
 		$this->set_acf_field_type( $acf_field_type );
@@ -53,9 +53,7 @@ class AcfGraphQLFieldType {
 	}
 
 	/**
-	 * @param array|callable $config The config for the ACF GraphQL Field Type
-	 *
-	 * @return void
+	 * @param array<mixed>|callable $config The config for the ACF GraphQL Field Type
 	 */
 	public function set_config( $config = [] ): void {
 		$_config = [];
@@ -95,7 +93,7 @@ class AcfGraphQLFieldType {
 	/**
 	 * Return Admin Field Settings for configuring GraphQL Behavior.
 	 *
-	 * @param array $field The Instance of the ACF Field the settings are for
+	 * @param array<mixed>                  $field The Instance of the ACF Field the settings are for
 	 * @param \WPGraphQL\Acf\Admin\Settings $settings The Settings class
 	 *
 	 * @return mixed|void
@@ -179,11 +177,11 @@ class AcfGraphQLFieldType {
 	}
 
 	/**
-	 * @param array $acf_field The ACF Field to get the settings for
-	 * @param array $default_admin_settings The default admin settings
+	 * @param array<mixed>                  $acf_field The ACF Field to get the settings for
+	 * @param array<mixed>                  $default_admin_settings The default admin settings
 	 * @param \WPGraphQL\Acf\Admin\Settings $settings Instance of the Settings class
 	 *
-	 * @return array
+	 * @return array<mixed>
 	 */
 	public function get_admin_fields( array $acf_field, array $default_admin_settings, Settings $settings ): array {
 		if ( ! empty( $this->admin_fields ) ) {
@@ -204,8 +202,7 @@ class AcfGraphQLFieldType {
 	}
 
 	/**
-	 *
-	 * @return string
+	 * Get the ACF field_type for the field
 	 */
 	public function get_acf_field_type(): string {
 		return $this->acf_field_type;
@@ -215,17 +212,15 @@ class AcfGraphQLFieldType {
 	 * Set the ACF Field Type
 	 *
 	 * @param string $acf_field_type
-	 *
-	 * @return void
 	 */
 	protected function set_acf_field_type( string $acf_field_type ): void {
 		$this->acf_field_type = $acf_field_type;
 	}
 
 	/**
-	 * @return void
+	 * Set the field settings to be excluded for the field
 	 */
-	protected function set_excluded_admin_field_settings():void {
+	protected function set_excluded_admin_field_settings(): void {
 		$this->excluded_admin_field_settings = [];
 
 		$excluded_admin_fields = $this->get_config( 'exclude_admin_fields' );
@@ -242,21 +237,21 @@ class AcfGraphQLFieldType {
 	}
 
 	/**
-	 * @return array
+	 * @return array<mixed>
 	 */
 	public function get_excluded_admin_field_settings(): array {
 		return apply_filters( 'wpgraphql/acf/excluded_admin_field_settings', $this->excluded_admin_field_settings );
 	}
 
 	/**
-	 * @param mixed               $root The value of the previously resolved field in the tree
-	 * @param array               $args The arguments input on the field
-	 * @param \WPGraphQL\AppContext          $context The Context passed through resolution
-	 * @param \GraphQL\Type\Definition\ResolveInfo         $info Information about the field resolving
-	 * @param \WPGraphQL\Acf\AcfGraphQLFieldType $field_type The Type of ACF Field resolving
-	 * @param \WPGraphQL\Acf\FieldConfig         $field_config The Config of the ACF Field resolving
+	 * @param mixed                                $root The value of the previously resolved field in the tree
+	 * @param array<mixed>                         $args The arguments input on the field
+	 * @param \WPGraphQL\AppContext                $context The Context passed through resolution
+	 * @param \GraphQL\Type\Definition\ResolveInfo $info Information about the field resolving
+	 * @param \WPGraphQL\Acf\AcfGraphQLFieldType   $field_type The Type of ACF Field resolving
+	 * @param \WPGraphQL\Acf\FieldConfig           $field_config The Config of the ACF Field resolving
 	 *
-	 * @return array|callable|mixed|null
+	 * @return array<mixed>|callable|mixed|null
 	 */
 	public function get_resolver( $root, array $args, AppContext $context, ResolveInfo $info, self $field_type, FieldConfig $field_config ) {
 		$acf_field = $field_config->get_acf_field();
@@ -297,7 +292,9 @@ class AcfGraphQLFieldType {
 	/**
 	 * Determine the GraphQL Type the field should resolve as.
 	 *
-	 * @return array|string
+	 * @param \WPGraphQL\Acf\FieldConfig $field_config
+	 *
+	 * @return array<mixed>|string
 	 */
 	public function get_resolve_type( FieldConfig $field_config ) {
 		$acf_field = $field_config->get_acf_field();
@@ -334,5 +331,4 @@ class AcfGraphQLFieldType {
 
 		return $resolve_type;
 	}
-
 }

--- a/src/Admin/OptionsPageRegistration.php
+++ b/src/Admin/OptionsPageRegistration.php
@@ -6,7 +6,7 @@ use WPGraphQL\Utils\Utils;
 class OptionsPageRegistration {
 
 	/**
-	 * @return void
+	 * Initialize Support for ACF Options Page UIs
 	 */
 	public function init(): void {
 
@@ -29,18 +29,18 @@ class OptionsPageRegistration {
 	}
 
 	/**
-	 * @param array $args
-	 * @param array $post
+	 * @param array<mixed> $args
+	 * @param array<mixed> $post
 	 *
-	 * @return array
+	 * @return array<mixed>
 	 */
-	public function add_registration_fields( array $args, array $post ) : array {
+	public function add_registration_fields( array $args, array $post ): array {
 		$show_in_graphql = false;
 
 		if ( isset( $args['show_in_graphql'] ) ) {
-			$show_in_graphql = $args['show_in_graphql'];
+			$show_in_graphql = (bool) $args['show_in_graphql'];
 		} elseif ( isset( $post['show_in_graphql'] ) ) {
-			$show_in_graphql = $post['show_in_graphql'];
+			$show_in_graphql = (bool) $post['show_in_graphql'];
 		}
 
 		$args['show_in_graphql'] = $show_in_graphql;
@@ -62,9 +62,9 @@ class OptionsPageRegistration {
 	}
 
 	/**
-	 * @param array $tabs
+	 * @param array<mixed> $tabs
 	 *
-	 * @return array
+	 * @return array<mixed>
 	 */
 	public function add_tabs( array $tabs ): array {
 		$tabs['graphql'] = __( 'GraphQL', 'wpgraphql-acf' );
@@ -72,9 +72,7 @@ class OptionsPageRegistration {
 	}
 
 	/**
-	 * @param array $acf_ui_options_page
-	 *
-	 * @return void
+	 * @param array<mixed> $acf_ui_options_page
 	 */
 	public function render_settings_tab( array $acf_ui_options_page ): void {
 		acf_render_field_wrap(
@@ -124,9 +122,9 @@ class OptionsPageRegistration {
 	/**
 	 * Given a list of columns, add "graphql_type" as a column.
 	 *
-	 * @param array $columns The columns on the post type table
+	 * @param array<mixed> $columns The columns on the post type table
 	 *
-	 * @return array
+	 * @return array<mixed>
 	 */
 	public function add_graphql_type_column( array $columns ): array {
 		$columns['show_in_graphql'] = __( 'Show in GraphQL', 'wpgraphql-acf' );
@@ -139,8 +137,6 @@ class OptionsPageRegistration {
 	 *
 	 * @param string $column_name The name of the column being rendered
 	 * @param int    $post_id     The ID of the post the column is being displayed for
-	 *
-	 * @return void
 	 */
 	public function render_graphql_columns( string $column_name, int $post_id ): void {
 		$post_type = acf_get_internal_post_type( $post_id, 'acf-ui-options-page' );
@@ -163,5 +159,4 @@ class OptionsPageRegistration {
 			default:
 		}
 	}
-
 }

--- a/src/Admin/PostTypeRegistration.php
+++ b/src/Admin/PostTypeRegistration.php
@@ -10,7 +10,7 @@ use WPGraphQL\Utils\Utils;
 class PostTypeRegistration {
 
 	/**
-	 * @return void
+	 * Initialize support for extending ACF Post Type Registration
 	 */
 	public function init(): void {
 
@@ -40,9 +40,9 @@ class PostTypeRegistration {
 	}
 
 	/**
-	 * @param array $tabs
+	 * @param array<mixed> $tabs
 	 *
-	 * @return array
+	 * @return array<mixed>
 	 */
 	public function add_tabs( array $tabs ): array {
 		$tabs['graphql'] = __( 'GraphQL', 'wpgraphql-acf' );
@@ -50,9 +50,7 @@ class PostTypeRegistration {
 	}
 
 	/**
-	 * @param array $acf_post_type
-	 *
-	 * @return void
+	 * @param array<mixed> $acf_post_type
 	 */
 	public function render_settings_tab( array $acf_post_type ): void {
 		acf_render_field_wrap(
@@ -129,10 +127,10 @@ class PostTypeRegistration {
 	}
 
 	/**
-	 * @param array $args
-	 * @param array $post_type
+	 * @param array<mixed> $args
+	 * @param array<mixed> $post_type
 	 *
-	 * @return array
+	 * @return array<mixed>
 	 */
 	public function add_cpt_registration_fields( array $args, array $post_type ): array {
 
@@ -170,8 +168,6 @@ class PostTypeRegistration {
 
 	/**
 	 * @param string $screen
-	 *
-	 * @return void
 	 */
 	public function enqueue_admin_scripts( string $screen ): void {
 		global $post;
@@ -200,9 +196,9 @@ class PostTypeRegistration {
 	/**
 	 * Given a list of columns, add "graphql_type" as a column.
 	 *
-	 * @param array $columns The columns on the post type table
+	 * @param array<mixed> $columns The columns on the post type table
 	 *
-	 * @return array
+	 * @return array<mixed>
 	 */
 	public function add_graphql_type_column( array $columns ): array {
 		$columns['show_in_graphql'] = __( 'Show in GraphQL', 'wpgraphql-acf' );
@@ -215,8 +211,6 @@ class PostTypeRegistration {
 	 *
 	 * @param string $column_name The name of the column being rendered
 	 * @param int    $post_id     The ID of the post the column is being displayed for
-	 *
-	 * @return void
 	 */
 	public function render_graphql_columns( string $column_name, int $post_id ): void {
 		$post_type = acf_get_internal_post_type( $post_id, 'acf-post-type' );
@@ -239,5 +233,4 @@ class PostTypeRegistration {
 			default:
 		}
 	}
-
 }

--- a/src/Admin/Settings.php
+++ b/src/Admin/Settings.php
@@ -2,16 +2,16 @@
 /**
  * ACF extension for WP-GraphQL
  *
- * @package wpgraphql-acf
+ * @package WPGraphQL\ACF
  */
 
 namespace WPGraphQL\Acf\Admin;
 
-use WP_Post;
 use WPGraphQL\Acf\AcfGraphQLFieldType;
 use WPGraphQL\Acf\LocationRules\LocationRules;
-use WPGraphQL\Acf\Utils;
 use WPGraphQL\Acf\Registry;
+use WPGraphQL\Acf\Utils;
+use WP_Post;
 
 
 /**
@@ -32,7 +32,7 @@ class Settings {
 	protected $registry;
 
 	/**
-	 * @return \WPGraphQL\Acf\Registry
+	 * Get the WPGraphQL for ACF Registry
 	 */
 	protected function get_registry(): Registry {
 		if ( ! $this->registry instanceof Registry ) {
@@ -99,8 +99,6 @@ class Settings {
 
 	/**
 	 * Set up the Field Settings for configuring how each field should map to GraphQL
-	 *
-	 * @return void
 	 */
 	protected function setup_field_settings(): void {
 		if ( ! function_exists( 'acf_get_field_types' ) ) {
@@ -139,8 +137,6 @@ class Settings {
 
 	/**
 	 * Handle the AJAX callback for converting ACF Location settings to GraphQL Types
-	 *
-	 * @return void
 	 */
 	public function graphql_types_ajax_callback(): void {
 		if ( ! isset( $_POST['data'] ) ) {
@@ -184,8 +180,6 @@ class Settings {
 
 	/**
 	 * Register the GraphQL Settings metabox for the ACF Field Group post type
-	 *
-	 * @return void
 	 */
 	public function register_meta_boxes(): void {
 		add_meta_box(
@@ -203,9 +197,8 @@ class Settings {
 	/**
 	 * Display the GraphQL Settings fields on the ACF Field Group add/edit admin page
 	 *
-	 * @param array|\WP_Post $field_group The Field Group being edited
+	 * @param array<mixed>|\WP_Post $field_group The Field Group being edited
 	 *
-	 * @return void
 	 * @throws \GraphQL\Error\Error
 	 * @throws \Exception
 	 */
@@ -238,7 +231,7 @@ class Settings {
 				'type'         => 'text',
 				'prefix'       => 'acf_field_group',
 				'name'         => 'graphql_field_name',
-				'required'     => isset( $field_group['show_in_graphql'] ) && $field_group['show_in_graphql'],
+				'required'     => isset( $field_group['show_in_graphql'] ) && (bool) $field_group['show_in_graphql'],
 				'placeholder'  => __( 'FieldGroupTypeName', 'wpgraphql-acf' ),
 				'value'        => ! empty( $field_group['graphql_field_name'] ) ? $field_group['graphql_field_name'] : '',
 			],
@@ -322,10 +315,8 @@ class Settings {
 	/**
 	 * Add settings to each field to show in GraphQL
 	 *
-	 * @param array $field The field to add the setting to.
-	 * @param string|null $field_type The Type of field being configured.
-	 *
-	 * @return void
+	 * @param array<mixed> $field The field to add the setting to.
+	 * @param string|null  $field_type The Type of field being configured.
 	 */
 	public function add_field_settings( array $field, ?string $field_type = null ): void {
 
@@ -382,9 +373,9 @@ class Settings {
 	/**
 	 * Get the config for the non_null field
 	 *
-	 * @param array $override Array of settings to override the default behavior
+	 * @param array<mixed> $override Array of settings to override the default behavior
 	 *
-	 * @return array
+	 * @return array<mixed>
 	 */
 	public function get_graphql_resolve_type_field_config( array $override = [] ): array {
 		return array_merge(
@@ -415,8 +406,6 @@ class Settings {
 	 * This enqueues admin script.
 	 *
 	 * @param string $screen The screen that scripts are being enqueued to
-	 *
-	 * @return void
 	 */
 	public function enqueue_graphql_acf_scripts( string $screen ): void {
 		global $post;
@@ -453,9 +442,9 @@ class Settings {
 	/**
 	 * Add header to the field group admin page columns showing types and interfaces
 	 *
-	 * @param array $_columns The column headers to add the values to.
+	 * @param array<mixed> $_columns The column headers to add the values to.
 	 *
-	 * @return array The column headers with the added wp-graphql columns
+	 * @return array<mixed> The column headers with the added wp-graphql columns
 	 */
 	public function wpgraphql_admin_table_column_headers( array $_columns ): array {
 		$columns  = [];
@@ -487,7 +476,6 @@ class Settings {
 	 * @param string $column_name The column being processed.
 	 * @param int    $post_id     The field group id being processed
 	 *
-	 * @return void
 	 * @throws \GraphQL\Error\Error
 	 */
 	public function wpgraphql_admin_table_columns_html( string $column_name, int $post_id ): void {
@@ -528,5 +516,4 @@ class Settings {
 				echo null;
 		}
 	}
-
 }

--- a/src/Admin/TaxonomyRegistration.php
+++ b/src/Admin/TaxonomyRegistration.php
@@ -10,7 +10,7 @@ use WPGraphQL\Utils\Utils;
 class TaxonomyRegistration {
 
 	/**
-	 * @return void
+	 * Initialize support for extending ACF Taxonomy Registration
 	 */
 	public function init(): void {
 
@@ -40,9 +40,9 @@ class TaxonomyRegistration {
 	}
 
 	/**
-	 * @param array $tabs
+	 * @param array<mixed> $tabs
 	 *
-	 * @return array
+	 * @return array<mixed>
 	 */
 	public function add_tabs( array $tabs ): array {
 		$tabs['graphql'] = __( 'GraphQL', 'wpgraphql-acf' );
@@ -50,9 +50,7 @@ class TaxonomyRegistration {
 	}
 
 	/**
-	 * @param array $acf_taxonomy
-	 *
-	 * @return void
+	 * @param array<mixed> $acf_taxonomy
 	 */
 	public function render_settings_tab( array $acf_taxonomy ): void {
 		acf_render_field_wrap(
@@ -127,10 +125,10 @@ class TaxonomyRegistration {
 	}
 
 	/**
-	 * @param array $args
-	 * @param array $taxonomy
+	 * @param array<mixed> $args
+	 * @param array<mixed> $taxonomy
 	 *
-	 * @return array
+	 * @return array<mixed>
 	 */
 	public function add_taxonomy_registration_fields( array $args, array $taxonomy ): array {
 
@@ -168,8 +166,6 @@ class TaxonomyRegistration {
 
 	/**
 	 * @param string $screen
-	 *
-	 * @return void
 	 */
 	public function enqueue_admin_scripts( string $screen ): void {
 		global $post;
@@ -198,9 +194,9 @@ class TaxonomyRegistration {
 	/**
 	 * Given a list of columns, add "graphql_type" as a column.
 	 *
-	 * @param array $columns The columns on the post type table
+	 * @param array<mixed> $columns The columns on the post type table
 	 *
-	 * @return array
+	 * @return array<mixed>
 	 */
 	public function add_graphql_type_column( array $columns ): array {
 		$columns['show_in_graphql'] = __( 'Show in GraphQL', 'wpgraphql-acf' );
@@ -213,8 +209,6 @@ class TaxonomyRegistration {
 	 *
 	 * @param string $column_name The name of the column being rendered
 	 * @param int    $post_id     The ID of the post the column is being displayed for
-	 *
-	 * @return void
 	 */
 	public function render_graphql_columns( string $column_name, int $post_id ): void {
 		$post_type = acf_get_internal_post_type( $post_id, 'acf-taxonomy' );
@@ -237,5 +231,4 @@ class TaxonomyRegistration {
 			default:
 		}
 	}
-
 }

--- a/src/Data/Loader/AcfOptionsPageLoader.php
+++ b/src/Data/Loader/AcfOptionsPageLoader.php
@@ -7,9 +7,9 @@ use WPGraphQL\Data\Loader\AbstractDataLoader;
 class AcfOptionsPageLoader extends AbstractDataLoader {
 
 	/**
-	 * @param array $keys
+	 * @param array<mixed> $keys
 	 *
-	 * @return array
+	 * @return array<mixed>
 	 * @throws \Exception
 	 */
 	protected function loadKeys( array $keys ): array {

--- a/src/FieldConfig.php
+++ b/src/FieldConfig.php
@@ -8,17 +8,17 @@ use WPGraphQL\AppContext;
 class FieldConfig {
 
 	/**
-	 * @var array
+	 * @var array<mixed>
 	 */
 	protected $acf_field;
 
 	/**
-	 * @var array
+	 * @var array<mixed>
 	 */
 	protected $raw_field;
 
 	/**
-	 * @var array
+	 * @var array<mixed>
 	 */
 	protected $acf_field_group;
 
@@ -48,6 +48,10 @@ class FieldConfig {
 	protected $graphql_parent_type_name;
 
 	/**
+	 * @param array<mixed>            $acf_field The ACF Field being mapped to the GraphQL Schema
+	 * @param array<mixed>            $acf_field_group The ACF Field Group the field belongs to
+	 * @param \WPGraphQL\Acf\Registry $registry The WPGraphQL for ACF Type Registry
+	 *
 	 * @throws \GraphQL\Error\Error
 	 */
 	public function __construct( array $acf_field, array $acf_field_group, Registry $registry ) {
@@ -61,31 +65,30 @@ class FieldConfig {
 	}
 
 	/**
-	 * @return \WPGraphQL\Acf\Registry
+	 * Get the WPGraphQL for ACF TypeRegistry instance
 	 */
 	public function get_registry(): Registry {
 		return $this->registry;
 	}
 
 	/**
-	 * @return string|null
+	 * Get the GraphQL Type Name for the current ACF Field Group
 	 */
 	public function get_graphql_field_group_type_name(): ?string {
 		return $this->graphql_field_group_type_name;
 	}
 
 	/**
-	 * @return \WPGraphQL\Acf\AcfGraphQLFieldType|null
+	 * Get the AcfGraphQLFieldType definition for an ACF Field
 	 */
 	public function get_graphql_field_type(): ?AcfGraphQLFieldType {
 		return $this->graphql_field_type;
 	}
 
 	/**
-	 * @param array       $acf_field
-	 * @param string|null $prepend
+	 * @param array<mixed> $acf_field
+	 * @param string|null  $prepend
 	 *
-	 * @return string
 	 * @throws \GraphQL\Error\Error
 	 */
 	public function get_parent_graphql_type_name( array $acf_field, ?string $prepend = '' ): string {
@@ -111,7 +114,7 @@ class FieldConfig {
 	}
 
 	/**
-	 * @return string
+	 * Get the GraphQL field name of the ACF Field
 	 */
 	public function get_graphql_field_name(): string {
 		return $this->graphql_field_name;
@@ -119,8 +122,6 @@ class FieldConfig {
 
 	/**
 	 * Determine whether an ACF Field is supported by GraphQL
-	 *
-	 * @return bool
 	 */
 	protected function is_supported_field_type(): bool {
 		$supported_types = Utils::get_supported_acf_fields_types();
@@ -130,7 +131,6 @@ class FieldConfig {
 	/**
 	 * Get the description of the field for the GraphQL Schema
 	 *
-	 * @return string
 	 * @throws \GraphQL\Error\Error
 	 */
 	public function get_field_description(): string {
@@ -157,36 +157,36 @@ class FieldConfig {
 	}
 
 	/**
-	 * @return array
+	 * @return array<mixed>
 	 */
 	public function get_acf_field(): array {
 		return $this->acf_field;
 	}
 
 	/**
-	 * @return array
+	 * @return array<mixed>
 	 */
 	public function get_raw_acf_field(): array {
 		return $this->raw_field;
 	}
 
 	/**
-	 * @return array
+	 * @return array<mixed>
 	 */
 	public function get_acf_field_group(): array {
 		return $this->acf_field_group;
 	}
 
 	/**
-	 * @return array|null
+	 * @return array<mixed>|null
 	 * @throws \GraphQL\Error\Error
 	 * @throws \Exception
 	 */
-	public function get_graphql_field_config():?array {
+	public function get_graphql_field_config(): ?array {
 
 		// if the field is explicitly set to not show in graphql, leave it out of the schema
 		// if the field is explicitly set to not show in graphql, leave it out of the schema
-		if ( isset( $this->acf_field['show_in_graphql'] ) && false === $this->acf_field['show_in_graphql'] ) {
+		if ( isset( $this->acf_field['show_in_graphql'] ) && false === (bool) $this->acf_field['show_in_graphql'] ) {
 			return null;
 		}
 
@@ -302,8 +302,6 @@ class FieldConfig {
 	 * the field using get_field()
 	 *
 	 * @param string $field_type The ACF Field Type of field being resolved
-	 *
-	 * @return bool
 	 */
 	public function should_format_field_value( string $field_type ): bool {
 
@@ -321,10 +319,10 @@ class FieldConfig {
 	}
 
 	/**
-	 * @param string $selector
-	 * @param string|null $parent_field_name
+	 * @param string          $selector
+	 * @param string|null     $parent_field_name
 	 * @param string|int|null $post_id
-	 * @param bool $should_format
+	 * @param bool            $should_format
 	 *
 	 * @return false|mixed
 	 */
@@ -339,11 +337,11 @@ class FieldConfig {
 	}
 
 	/**
-	 * @param mixed       $root
-	 * @param array       $args
-	 * @param \WPGraphQL\AppContext  $context
+	 * @param mixed                                $root
+	 * @param array<mixed>                         $args
+	 * @param \WPGraphQL\AppContext                $context
 	 * @param \GraphQL\Type\Definition\ResolveInfo $info
-	 * @param array $acf_field The ACF Field to resolve for
+	 * @param array<mixed>                         $acf_field The ACF Field to resolve for
 	 *
 	 * @return mixed
 	 */
@@ -545,17 +543,14 @@ class FieldConfig {
 
 	/**
 	 * @param string $to_type
-	 *
-	 * @return string
 	 */
 	public function get_connection_name( string $to_type ): string {
 		return \WPGraphQL\Utils\Utils::format_type_name( 'Acf' . ucfirst( $to_type ) . 'Connection' );
 	}
 
 	/**
-	 * @param array $config The Connection Config to use
+	 * @param array<mixed> $config The Connection Config to use
 	 *
-	 * @return void
 	 * @throws \Exception
 	 */
 	public function register_graphql_connections( array $config ): void {
@@ -597,5 +592,4 @@ class FieldConfig {
 
 		$this->registry->register_field_group( $connection_key, $connection_config );
 	}
-
 }

--- a/src/FieldType/ButtonGroup.php
+++ b/src/FieldType/ButtonGroup.php
@@ -4,15 +4,14 @@ namespace WPGraphQL\Acf\FieldType;
 class ButtonGroup {
 
 	/**
-	 * @return void
+	 * Register support for the "button_group" ACF field type
 	 */
 	public static function register_field_type(): void {
 		register_graphql_acf_field_type(
 			'button_group',
 			[
 				'graphql_type' => 'String',
-			] 
+			]
 		);
 	}
-
 }

--- a/src/FieldType/Checkbox.php
+++ b/src/FieldType/Checkbox.php
@@ -4,15 +4,14 @@ namespace WPGraphQL\Acf\FieldType;
 class Checkbox {
 
 	/**
-	 * @return void
+	 * Register support for the "checkbox" ACF field type
 	 */
 	public static function register_field_type(): void {
 		register_graphql_acf_field_type(
 			'checkbox',
 			[
 				'graphql_type' => [ 'list_of' => 'String' ],
-			] 
+			]
 		);
 	}
-
 }

--- a/src/FieldType/CloneField.php
+++ b/src/FieldType/CloneField.php
@@ -8,9 +8,9 @@ use WPGraphQL\Utils\Utils;
 class CloneField {
 
 	/**
-	 * @return void
+	 * Register support for the 'clone' acf field type
 	 */
-	public static function register_field_type():void {
+	public static function register_field_type(): void {
 		register_graphql_acf_field_type(
 			'clone',
 			[
@@ -97,12 +97,11 @@ class CloneField {
 	}
 
 	/**
-	 * @param string      $type_name The name of the GraphQL Type representing the prefixed clone field
-	 * @param array       $sub_field_group  The Field Group representing the cloned field
-	 * @param array       $cloned_fields The cloned fields to be registered to the Cloned Field Type
+	 * @param string                     $type_name The name of the GraphQL Type representing the prefixed clone field
+	 * @param array<mixed>               $sub_field_group  The Field Group representing the cloned field
+	 * @param array<mixed>               $cloned_fields The cloned fields to be registered to the Cloned Field Type
 	 * @param \WPGraphQL\Acf\FieldConfig $field_config The ACF Field Config
 	 *
-	 * @return string
 	 * @throws \Exception
 	 */
 	public static function register_prefixed_clone_field_type( string $type_name, array $sub_field_group, array $cloned_fields, FieldConfig $field_config ): string {

--- a/src/FieldType/ColorPicker.php
+++ b/src/FieldType/ColorPicker.php
@@ -4,15 +4,14 @@ namespace WPGraphQL\Acf\FieldType;
 class ColorPicker {
 
 	/**
-	 * @return void
+	 * Register support for the "color_picker" ACF field type
 	 */
 	public static function register_field_type(): void {
 		register_graphql_acf_field_type(
 			'color_picker',
 			[
 				'graphql_type' => 'String',
-			] 
+			]
 		);
 	}
-
 }

--- a/src/FieldType/DatePicker.php
+++ b/src/FieldType/DatePicker.php
@@ -6,7 +6,7 @@ use WPGraphQL\Acf\FieldConfig;
 class DatePicker {
 
 	/**
-	 * @return void
+	 * Register support for the "date_picker" ACF field type
 	 */
 	public static function register_field_type(): void {
 		register_graphql_acf_field_type(
@@ -41,5 +41,4 @@ class DatePicker {
 			]
 		);
 	}
-
 }

--- a/src/FieldType/DateTimePicker.php
+++ b/src/FieldType/DateTimePicker.php
@@ -7,7 +7,7 @@ use WPGraphQL\Acf\FieldConfig;
 class DateTimePicker {
 
 	/**
-	 * @return void
+	 * Register support for the "date_time_picker" ACF field type
 	 */
 	public static function register_field_type(): void {
 		register_graphql_acf_field_type(
@@ -41,5 +41,4 @@ class DateTimePicker {
 			]
 		);
 	}
-
 }

--- a/src/FieldType/Email.php
+++ b/src/FieldType/Email.php
@@ -4,15 +4,14 @@ namespace WPGraphQL\Acf\FieldType;
 class Email {
 
 	/**
-	 * @return void
+	 * Register support for the "email" ACF field type
 	 */
 	public static function register_field_type(): void {
 		register_graphql_acf_field_type(
 			'email',
 			[
 				'graphql_type' => 'String',
-			] 
+			]
 		);
 	}
-
 }

--- a/src/FieldType/File.php
+++ b/src/FieldType/File.php
@@ -3,15 +3,15 @@
 namespace WPGraphQL\Acf\FieldType;
 
 use GraphQL\Type\Definition\ResolveInfo;
-use WPGraphQL\AppContext;
-use WPGraphQL\Data\Connection\PostObjectConnectionResolver;
 use WPGraphQL\Acf\AcfGraphQLFieldType;
 use WPGraphQL\Acf\FieldConfig;
+use WPGraphQL\AppContext;
+use WPGraphQL\Data\Connection\PostObjectConnectionResolver;
 
 class File {
 
 	/**
-	 * @return void
+	 * Register support for the "file" ACF field type
 	 */
 	public static function register_field_type(): void {
 		register_graphql_acf_field_type(
@@ -66,5 +66,4 @@ class File {
 			]
 		);
 	}
-
 }

--- a/src/FieldType/FlexibleContent.php
+++ b/src/FieldType/FlexibleContent.php
@@ -1,14 +1,14 @@
 <?php
 namespace WPGraphQL\Acf\FieldType;
 
-use WPGraphQL\Utils\Utils;
 use WPGraphQL\Acf\AcfGraphQLFieldType;
 use WPGraphQL\Acf\FieldConfig;
+use WPGraphQL\Utils\Utils;
 
 class FlexibleContent {
 
 	/**
-	 * @return void
+	 * Register support for the "flexible_content" ACF field type
 	 */
 	public static function register_field_type(): void {
 		register_graphql_acf_field_type(
@@ -31,15 +31,15 @@ class FlexibleContent {
 								'fields'          => [
 									'fieldGroupName' => [
 										'type'        => 'String',
-										'resolve'     => static function ( $object ) use ( $layout_interface_prefix ) {
-											$layout = $object['acf_fc_layout'] ?? null;
+										'resolve'     => static function ( $source ) use ( $layout_interface_prefix ) {
+											$layout = $source['acf_fc_layout'] ?? null;
 											return Utils::format_type_name( $layout_interface_prefix . ' ' . $layout ) . 'Layout';
 										},
 										'description' => __( 'The name of the ACF Flex Field Layout', 'wpgraphql-acf' ),
 									],
 								],
-								'resolveType'     => static function ( $object ) use ( $layout_interface_prefix ) {
-									$layout = $object['acf_fc_layout'] ?? null;
+								'resolveType'     => static function ( $source ) use ( $layout_interface_prefix ) {
+									$layout = $source['acf_fc_layout'] ?? null;
 									return Utils::format_type_name( $layout_interface_prefix . ' ' . $layout ) . 'Layout';
 								},
 							]
@@ -88,5 +88,4 @@ class FlexibleContent {
 			]
 		);
 	}
-
 }

--- a/src/FieldType/Gallery.php
+++ b/src/FieldType/Gallery.php
@@ -1,15 +1,15 @@
 <?php
 namespace WPGraphQL\Acf\FieldType;
 
-use WPGraphQL\AppContext;
-use WPGraphQL\Data\Connection\PostObjectConnectionResolver;
 use WPGraphQL\Acf\AcfGraphQLFieldType;
 use WPGraphQL\Acf\FieldConfig;
+use WPGraphQL\AppContext;
+use WPGraphQL\Data\Connection\PostObjectConnectionResolver;
 
 class Gallery {
 
 	/**
-	 * @return void
+	 * Register support for the "gallery" ACF field type
 	 */
 	public static function register_field_type(): void {
 		register_graphql_acf_field_type(
@@ -72,5 +72,4 @@ class Gallery {
 			]
 		);
 	}
-
 }

--- a/src/FieldType/GoogleMap.php
+++ b/src/FieldType/GoogleMap.php
@@ -4,15 +4,14 @@ namespace WPGraphQL\Acf\FieldType;
 class GoogleMap {
 
 	/**
-	 * @return void
+	 * Register support for the "google_map" ACF field type
 	 */
 	public static function register_field_type(): void {
 		register_graphql_acf_field_type(
 			'google_map',
 			[
 				'graphql_type' => 'AcfGoogleMap',
-			] 
+			]
 		);
 	}
-
 }

--- a/src/FieldType/Group.php
+++ b/src/FieldType/Group.php
@@ -1,15 +1,15 @@
 <?php
 namespace WPGraphQL\Acf\FieldType;
 
-use WPGraphQL\AppContext;
-use WPGraphQL\Utils\Utils;
 use WPGraphQL\Acf\AcfGraphQLFieldType;
 use WPGraphQL\Acf\FieldConfig;
+use WPGraphQL\AppContext;
+use WPGraphQL\Utils\Utils;
 
 class Group {
 
 	/**
-	 * @return void
+	 * Register support for the "group" ACF field type
 	 */
 	public static function register_field_type(): void {
 		register_graphql_acf_field_type(
@@ -49,5 +49,4 @@ class Group {
 			]
 		);
 	}
-
 }

--- a/src/FieldType/Image.php
+++ b/src/FieldType/Image.php
@@ -2,15 +2,15 @@
 namespace WPGraphQL\Acf\FieldType;
 
 use GraphQL\Type\Definition\ResolveInfo;
-use WPGraphQL\AppContext;
-use WPGraphQL\Data\Connection\PostObjectConnectionResolver;
 use WPGraphQL\Acf\AcfGraphQLFieldType;
 use WPGraphQL\Acf\FieldConfig;
+use WPGraphQL\AppContext;
+use WPGraphQL\Data\Connection\PostObjectConnectionResolver;
 
 class Image {
 
 	/**
-	 * @return void
+	 * Register support for the "image" ACF field type
 	 */
 	public static function register_field_type(): void {
 		register_graphql_acf_field_type(
@@ -65,5 +65,4 @@ class Image {
 			]
 		);
 	}
-
 }

--- a/src/FieldType/Link.php
+++ b/src/FieldType/Link.php
@@ -4,15 +4,14 @@ namespace WPGraphQL\Acf\FieldType;
 class Link {
 
 	/**
-	 * @return void
+	 * Register support for the "link" ACF field type
 	 */
 	public static function register_field_type(): void {
 		register_graphql_acf_field_type(
 			'link',
 			[
 				'graphql_type' => 'AcfLink',
-			] 
+			]
 		);
 	}
-
 }

--- a/src/FieldType/Number.php
+++ b/src/FieldType/Number.php
@@ -4,15 +4,14 @@ namespace WPGraphQL\Acf\FieldType;
 class Number {
 
 	/**
-	 * @return void
+	 * Register support for the "number" ACF field type
 	 */
 	public static function register_field_type(): void {
 		register_graphql_acf_field_type(
 			'number',
 			[
 				'graphql_type' => 'Float',
-			] 
+			]
 		);
 	}
-
 }

--- a/src/FieldType/Oembed.php
+++ b/src/FieldType/Oembed.php
@@ -4,15 +4,14 @@ namespace WPGraphQL\Acf\FieldType;
 class Oembed {
 
 	/**
-	 * @return void
+	 * Register support for the "oembed" ACF field type
 	 */
 	public static function register_field_type(): void {
 		register_graphql_acf_field_type(
 			'oembed',
 			[
 				'graphql_type' => 'String',
-			] 
+			]
 		);
 	}
-
 }

--- a/src/FieldType/PageLink.php
+++ b/src/FieldType/PageLink.php
@@ -7,7 +7,7 @@ use WPGraphQL\Acf\FieldConfig;
 class PageLink {
 
 	/**
-	 * @return void
+	 * Register support for the "page_link" ACF field type
 	 */
 	public static function register_field_type(): void {
 		register_graphql_acf_field_type(
@@ -23,5 +23,4 @@ class PageLink {
 			]
 		);
 	}
-
 }

--- a/src/FieldType/Password.php
+++ b/src/FieldType/Password.php
@@ -4,15 +4,14 @@ namespace WPGraphQL\Acf\FieldType;
 class Password {
 
 	/**
-	 * @return void
+	 * Register support for the "password" ACF field type
 	 */
 	public static function register_field_type(): void {
 		register_graphql_acf_field_type(
 			'password',
 			[
 				'graphql_type' => 'String',
-			] 
+			]
 		);
 	}
-
 }

--- a/src/FieldType/PostObject.php
+++ b/src/FieldType/PostObject.php
@@ -7,7 +7,7 @@ use WPGraphQL\Acf\FieldConfig;
 class PostObject {
 
 	/**
-	 * @return void
+	 * Register support for the ACF post_object field type
 	 */
 	public static function register_field_type(): void {
 		register_graphql_acf_field_type(
@@ -23,5 +23,4 @@ class PostObject {
 			]
 		);
 	}
-
 }

--- a/src/FieldType/Radio.php
+++ b/src/FieldType/Radio.php
@@ -4,15 +4,14 @@ namespace WPGraphQL\Acf\FieldType;
 class Radio {
 
 	/**
-	 * @return void
+	 * Register support for the "radio" ACF field type
 	 */
 	public static function register_field_type(): void {
 		register_graphql_acf_field_type(
 			'radio',
 			[
 				'graphql_type' => 'String',
-			] 
+			]
 		);
 	}
-
 }

--- a/src/FieldType/Range.php
+++ b/src/FieldType/Range.php
@@ -6,7 +6,7 @@ use WPGraphQL\Acf\FieldConfig;
 class Range {
 
 	/**
-	 * @return void
+	 * Register support for the "range" ACF field type
 	 */
 	public static function register_field_type(): void {
 		register_graphql_acf_field_type(
@@ -17,8 +17,7 @@ class Range {
 					$value = $field_config->resolve_field( $root, $args, $context, $info );
 					return (float) $value;
 				},
-			] 
+			]
 		);
 	}
-
 }

--- a/src/FieldType/Relationship.php
+++ b/src/FieldType/Relationship.php
@@ -1,17 +1,35 @@
 <?php
 namespace WPGraphQL\Acf\FieldType;
 
-use WPGraphQL\AppContext;
-use WPGraphQL\Data\Connection\PostObjectConnectionResolver;
 use WPGraphQL\Acf\AcfGraphQLFieldType;
 use WPGraphQL\Acf\FieldConfig;
+use WPGraphQL\AppContext;
+use WPGraphQL\Data\Connection\PostObjectConnectionResolver;
 
 class Relationship {
 
 	/**
-	 * @param array                         $admin_fields Admin Fields to display in the GraphQL Tab when configuring an ACF Field within a Field Group
-	 * @param array                         $field The
-	 * @param array                         $config
+	 * Register support for the "textarea" ACF field type
+	 */
+	public static function register_field_type(): void {
+		register_graphql_acf_field_type(
+			'relationship',
+			[
+				'exclude_admin_fields' => [ 'graphql_non_null' ],
+				'admin_fields'         => static function ( $admin_fields, $field, $config, \WPGraphQL\Acf\Admin\Settings $settings ): array {
+					return self::get_admin_fields( $admin_fields, $field, $config, $settings );
+				},
+				'graphql_type'         => static function ( FieldConfig $field_config, AcfGraphQLFieldType $acf_field_type ) {
+					return self::get_graphql_type( $field_config, $acf_field_type );
+				},
+			]
+		);
+	}
+
+	/**
+	 * @param array<mixed>                  $admin_fields Admin Fields to display in the GraphQL Tab when configuring an ACF Field within a Field Group
+	 * @param array<mixed>                  $field The ACF Field the settings belong to
+	 * @param array<mixed>                  $config The
 	 * @param \WPGraphQL\Acf\Admin\Settings $settings
 	 *
 	 * @return mixed
@@ -36,7 +54,6 @@ class Relationship {
 	 * @param \WPGraphQL\Acf\FieldConfig         $field_config
 	 * @param \WPGraphQL\Acf\AcfGraphQLFieldType $acf_field_type
 	 *
-	 * @return string
 	 * @throws \Exception
 	 */
 	public static function get_graphql_type( FieldConfig $field_config, AcfGraphQLFieldType $acf_field_type ): string {
@@ -98,23 +115,5 @@ class Relationship {
 		$field_config->register_graphql_connections( $connection_config );
 
 		return 'connection';
-	}
-
-	/**
-	 * @return void
-	 */
-	public static function register_field_type():void {
-		register_graphql_acf_field_type(
-			'relationship',
-			[
-				'exclude_admin_fields' => [ 'graphql_non_null' ],
-				'admin_fields'         => static function ( $admin_fields, $field, $config, \WPGraphQL\Acf\Admin\Settings $settings ): array {
-					return self::get_admin_fields( $admin_fields, $field, $config, $settings );
-				},
-				'graphql_type'         => static function ( FieldConfig $field_config, AcfGraphQLFieldType $acf_field_type ) {
-					return self::get_graphql_type( $field_config, $acf_field_type );
-				},
-			]
-		);
 	}
 }

--- a/src/FieldType/Repeater.php
+++ b/src/FieldType/Repeater.php
@@ -1,14 +1,14 @@
 <?php
 namespace WPGraphQL\Acf\FieldType;
 
-use WPGraphQL\Utils\Utils;
 use WPGraphQL\Acf\AcfGraphQLFieldType;
 use WPGraphQL\Acf\FieldConfig;
+use WPGraphQL\Utils\Utils;
 
 class Repeater {
 
 	/**
-	 * @return void
+	 * Register support for the "repeater" ACF field type
 	 */
 	public static function register_field_type(): void {
 		register_graphql_acf_field_type(
@@ -45,5 +45,4 @@ class Repeater {
 			]
 		);
 	}
-
 }

--- a/src/FieldType/Select.php
+++ b/src/FieldType/Select.php
@@ -4,15 +4,14 @@ namespace WPGraphQL\Acf\FieldType;
 class Select {
 
 	/**
-	 * @return void
+	 * Register support for the "select" ACF field type
 	 */
 	public static function register_field_type(): void {
 		register_graphql_acf_field_type(
 			'select',
 			[
 				'graphql_type' => [ 'list_of' => 'String' ],
-			] 
+			]
 		);
 	}
-
 }

--- a/src/FieldType/Taxonomy.php
+++ b/src/FieldType/Taxonomy.php
@@ -1,15 +1,15 @@
 <?php
 namespace WPGraphQL\Acf\FieldType;
 
-use WPGraphQL\AppContext;
-use WPGraphQL\Data\Connection\TermObjectConnectionResolver;
 use WPGraphQL\Acf\AcfGraphQLFieldType;
 use WPGraphQL\Acf\FieldConfig;
+use WPGraphQL\AppContext;
+use WPGraphQL\Data\Connection\TermObjectConnectionResolver;
 
 class Taxonomy {
 
 	/**
-	 * @return void
+	 * Register support for the "taxonomy" ACF field type
 	 */
 	public static function register_field_type(): void {
 		register_graphql_acf_field_type(
@@ -26,22 +26,29 @@ class Taxonomy {
 								return null;
 							}
 
+							$values = [];
 							if ( ! is_array( $value ) ) {
-								$value[] = $value;
+								$values[] = $value;
+							} else {
+								$values = $value;
 							}
 
-							$value = array_map(
+							$ids = array_map(
 								static function ( $id ) {
 									return absint( $id );
 								},
-								$value
+								$values
 							);
+
+							if ( empty( $ids ) ) {
+								return null;
+							}
 
 							$resolver = new TermObjectConnectionResolver( $root, $args, $context, $info );
 							return $resolver
 							// Set the query to include only the IDs passed in from the field
 							// and orderby the ids
-							->set_query_arg( 'include', $value )
+							->set_query_arg( 'include', $ids )
 							->set_query_arg( 'orderby', 'include' )
 							->get_connection();
 						},
@@ -55,5 +62,4 @@ class Taxonomy {
 			]
 		);
 	}
-
 }

--- a/src/FieldType/Text.php
+++ b/src/FieldType/Text.php
@@ -4,10 +4,9 @@ namespace WPGraphQL\Acf\FieldType;
 class Text {
 
 	/**
-	 * @return void
+	 * Register support for the "text" ACF field type
 	 */
 	public static function register_field_type(): void {
 		register_graphql_acf_field_type( 'text' );
 	}
-
 }

--- a/src/FieldType/Textarea.php
+++ b/src/FieldType/Textarea.php
@@ -4,10 +4,9 @@ namespace WPGraphQL\Acf\FieldType;
 class Textarea {
 
 	/**
-	 * @return void
+	 * Register support for the "textarea" ACF field type
 	 */
 	public static function register_field_type(): void {
 		register_graphql_acf_field_type( 'textarea' );
 	}
-
 }

--- a/src/FieldType/TimePicker.php
+++ b/src/FieldType/TimePicker.php
@@ -4,15 +4,14 @@ namespace WPGraphQL\Acf\FieldType;
 class TimePicker {
 
 	/**
-	 * @return void
+	 * Register support for the "time_picker" ACF field type
 	 */
 	public static function register_field_type(): void {
 		register_graphql_acf_field_type(
 			'time_picker',
 			[
 				'graphql_type' => 'String',
-			] 
+			]
 		);
 	}
-
 }

--- a/src/FieldType/TrueFalse.php
+++ b/src/FieldType/TrueFalse.php
@@ -4,15 +4,14 @@ namespace WPGraphQL\Acf\FieldType;
 class TrueFalse {
 
 	/**
-	 * @return void
+	 * Register support for the "true_false" ACF field type
 	 */
 	public static function register_field_type(): void {
 		register_graphql_acf_field_type(
 			'true_false',
 			[
 				'graphql_type' => 'Boolean',
-			] 
+			]
 		);
 	}
-
 }

--- a/src/FieldType/Url.php
+++ b/src/FieldType/Url.php
@@ -4,15 +4,14 @@ namespace WPGraphQL\Acf\FieldType;
 class Url {
 
 	/**
-	 * @return void
+	 * Register support for the "url" ACF field type
 	 */
 	public static function register_field_type(): void {
 		register_graphql_acf_field_type(
 			'url',
 			[
 				'graphql_type' => 'String',
-			] 
+			]
 		);
 	}
-
 }

--- a/src/FieldType/User.php
+++ b/src/FieldType/User.php
@@ -2,15 +2,15 @@
 namespace WPGraphQL\Acf\FieldType;
 
 use GraphQL\Type\Definition\ResolveInfo;
-use WPGraphQL\AppContext;
-use WPGraphQL\Data\Connection\UserConnectionResolver;
 use WPGraphQL\Acf\AcfGraphQLFieldType;
 use WPGraphQL\Acf\FieldConfig;
+use WPGraphQL\AppContext;
+use WPGraphQL\Data\Connection\UserConnectionResolver;
 
 class User {
 
 	/**
-	 * @return void
+	 * Register support for the "user" ACF field type
 	 */
 	public static function register_field_type(): void {
 		register_graphql_acf_field_type(
@@ -39,8 +39,9 @@ class User {
 									return null;
 								}
 
+								$values = [];
 								if ( ! is_array( $value ) ) {
-									$value = [ $value ];
+									$values[] = $value;
 								}
 
 								$value = array_map(
@@ -50,9 +51,8 @@ class User {
 										}
 										return absint( $user );
 									},
-									$value 
+									$values
 								);
-
 
 								$resolver = new UserConnectionResolver( $root, $args, $context, $info );
 								return $resolver->set_query_arg( 'include', $value )->set_query_arg( 'orderby', 'include' )->get_connection();
@@ -63,8 +63,7 @@ class User {
 					// The connection will be registered to the Schema so we return null for the field type
 					return 'connection';
 				},
-			] 
+			]
 		);
 	}
-
 }

--- a/src/FieldType/Wysiwyg.php
+++ b/src/FieldType/Wysiwyg.php
@@ -4,7 +4,7 @@ namespace WPGraphQL\Acf\FieldType;
 class Wysiwyg {
 
 	/**
-	 * @return void
+	 * Register support for the "wysiwyg" ACF field type
 	 */
 	public static function register_field_type(): void {
 		register_graphql_acf_field_type(
@@ -27,5 +27,4 @@ class Wysiwyg {
 			]
 		);
 	}
-
 }

--- a/src/FieldTypeRegistry.php
+++ b/src/FieldTypeRegistry.php
@@ -38,7 +38,7 @@ use WPGraphQL\Acf\FieldType\Wysiwyg;
 class FieldTypeRegistry {
 
 	/**
-	 * @var array
+	 * @var array<mixed>
 	 */
 	protected $registered_field_types = [];
 
@@ -59,7 +59,7 @@ class FieldTypeRegistry {
 
 
 	/**
-	 * @return void
+	 * Register ACF Field Types
 	 */
 	protected function register_acf_field_types(): void {
 
@@ -105,7 +105,7 @@ class FieldTypeRegistry {
 	/**
 	 * Return the registered field types, names and config in an associative array.
 	 *
-	 * @return array
+	 * @return array<mixed>
 	 */
 	public function get_registered_field_types(): array {
 		return apply_filters( 'wpgraphql/acf/get_registered_field_types', $this->registered_field_types );
@@ -114,7 +114,7 @@ class FieldTypeRegistry {
 	/**
 	 * Return an array of the names of the registered field types
 	 *
-	 * @return array
+	 * @return array<string>
 	 */
 	public function get_registered_field_type_names(): array {
 		return array_keys( $this->get_registered_field_types() );
@@ -125,8 +125,6 @@ class FieldTypeRegistry {
 	 * the field type to GraphQL
 	 *
 	 * @param string $acf_field_type The type of field to get the config for
-	 *
-	 * @return \WPGraphQL\Acf\AcfGraphQLFieldType|null
 	 */
 	public function get_field_type( string $acf_field_type ): ?AcfGraphQLFieldType {
 		return $this->registered_field_types[ $acf_field_type ] ?? null;
@@ -135,10 +133,8 @@ class FieldTypeRegistry {
 	/**
 	 * Register an ACF Field Type
 	 *
-	 * @param string $acf_field_type The name of the ACF Field Type to map to the GraphQL Schema
-	 * @param array|callable $config Config for mapping the ACF Field Type to the GraphQL Schema
-	 *
-	 * @return \WPGraphQL\Acf\AcfGraphQLFieldType
+	 * @param string                $acf_field_type The name of the ACF Field Type to map to the GraphQL Schema
+	 * @param array<mixed>|callable $config Config for mapping the ACF Field Type to the GraphQL Schema
 	 */
 	public function register_field_type( string $acf_field_type, $config = [] ): AcfGraphQLFieldType {
 		if ( isset( $this->registered_field_types[ $acf_field_type ] ) ) {
@@ -149,5 +145,4 @@ class FieldTypeRegistry {
 
 		return $this->registered_field_types[ $acf_field_type ];
 	}
-
 }

--- a/src/LocationRules/LocationRules.php
+++ b/src/LocationRules/LocationRules.php
@@ -28,26 +28,26 @@ class LocationRules {
 	/**
 	 * The field groups that have location rules mapped.
 	 *
-	 * @var array
+	 * @var array<mixed>
 	 */
 	public $mapped_field_groups = [];
 
 	/**
-	 * @var array
+	 * @var array<mixed>
 	 */
 	public $unset_types = [];
 
 	/**
 	 * The field groups to map to location rules
 	 *
-	 * @var array|mixed
+	 * @var array<mixed>
 	 */
 	public $acf_field_groups = [];
 
 	/**
 	 * LocationRules constructor.
 	 *
-	 * @param array $acf_field_groups
+	 * @param array<mixed> $acf_field_groups
 	 */
 	public function __construct( array $acf_field_groups = [] ) {
 		$this->acf_field_groups = ! empty( $acf_field_groups ) ? $acf_field_groups : acf_get_field_groups();
@@ -59,21 +59,17 @@ class LocationRules {
 	 *
 	 * @param string $field_group_name  The name of the ACF Field Group
 	 * @param string $graphql_type_name The name of the GraphQL Type
-	 *
-	 * @return void
 	 */
 	public function set_graphql_type( string $field_group_name, string $graphql_type_name ): void {
-		$this->mapped_field_groups[ Utils::format_field_name( $field_group_name, true ) ][] = ucfirst( Utils::format_field_name( $graphql_type_name, true ) );
+		$this->mapped_field_groups[ strtolower( Utils::format_field_name( $field_group_name, true ) ) ][] = ucfirst( Utils::format_field_name( $graphql_type_name, true ) );
 	}
 
 	/**
-	 * Given the name of a GraphqL Field Group and the name of a GraphQL Type, this unsets the
+	 * Given the name of a GraphQL Field Group and the name of a GraphQL Type, this unsets the
 	 * GraphQL Type for the field group
 	 *
 	 * @param string $field_group_name  The name of the ACF Field Group
 	 * @param string $graphql_type_name The name of the GraphQL Type
-	 *
-	 * @return void
 	 */
 	public function unset_graphql_type( string $field_group_name, string $graphql_type_name ): void {
 		$this->unset_types[ Utils::format_field_name( $field_group_name, true ) ][] = ucfirst( Utils::format_field_name( $graphql_type_name, true ) );
@@ -82,7 +78,7 @@ class LocationRules {
 	/**
 	 * Get the rules
 	 *
-	 * @return array
+	 * @return array<mixed>
 	 */
 	public function get_rules() {
 		if ( empty( $this->mapped_field_groups ) ) {
@@ -130,11 +126,9 @@ class LocationRules {
 	 *
 	 * If we detect conflicting rules, the rule set is not applied at all.
 	 *
-	 * @param array $and_params     The parameters of the rule group
-	 * @param mixed $param          The current param being evaluated
-	 * @param array $allowed_params The allowed params that shouldn't conflict
-	 *
-	 * @return bool
+	 * @param array<mixed> $and_params     The parameters of the rule group
+	 * @param mixed        $param          The current param being evaluated
+	 * @param array<mixed> $allowed_params The allowed params that shouldn't conflict
 	 */
 	public function check_for_conflicts( array $and_params, $param, array $allowed_params = [] ): bool {
 		if ( empty( $and_params ) ) {
@@ -167,10 +161,8 @@ class LocationRules {
 	 *
 	 * If we detect conflicting rules, the rule set is not applied at all.
 	 *
-	 * @param array $and_params The parameters of the rule group
-	 * @param string $param      The current param being evaluated
-	 *
-	 * @return bool
+	 * @param array<mixed> $and_params The parameters of the rule group
+	 * @param string       $param      The current param being evaluated
 	 */
 	public function check_params_for_conflicts( array $and_params = [], string $param = '' ): bool {
 		switch ( $param ) {
@@ -261,8 +253,6 @@ class LocationRules {
 	 * @param string $param            The parameter of the rule
 	 * @param string $operator         The operator of the rule
 	 * @param string $value            The value of the rule
-	 *
-	 * @return void
 	 */
 	public function determine_rules( string $field_group_name, string $param, string $operator, string $value ): void {
 
@@ -277,12 +267,10 @@ class LocationRules {
 				$this->determine_post_template_rules( $field_group_name, $param, $operator, $value );
 				break;
 			case 'post_status':
-				$this->determine_post_status_rules( $field_group_name, $param, $operator, $value );
 				break;
 			case 'post_format':
 			case 'post_category':
 			case 'post_taxonomy':
-				$this->determine_post_taxonomy_rules( $field_group_name, $param, $operator, $value );
 				break;
 			case 'post':
 				$this->determine_post_rules( $field_group_name, $param, $operator, $value );
@@ -347,8 +335,6 @@ class LocationRules {
 	/**
 	 * Determine GraphQL Schema location rules based on ACF Location rules for field groups
 	 * that are configured with no `graphql_types` field.
-	 *
-	 * @return void
 	 */
 	public function determine_location_rules(): void {
 		if ( ! empty( $this->acf_field_groups ) ) {
@@ -394,7 +380,7 @@ class LocationRules {
 	/**
 	 * Returns an array of Post Templates
 	 *
-	 * @return array
+	 * @return array<mixed>
 	 */
 	public function get_graphql_post_template_types(): array {
 		$page_templates = [
@@ -419,8 +405,6 @@ class LocationRules {
 	 * @param string $param            The parameter of the rule
 	 * @param string $operator         The operator of the rule
 	 * @param string $value            The value of the rule
-	 *
-	 * @return void
 	 */
 	public function determine_post_type_rules( string $field_group_name, string $param, string $operator, string $value ): void {
 		$allowed_post_types = get_post_types( [ 'show_in_graphql' => true ] );
@@ -478,8 +462,6 @@ class LocationRules {
 	 * @param string $param            The parameter of the rule
 	 * @param string $operator         The operator of the rule
 	 * @param string $value            The value of the rule
-	 *
-	 * @return void
 	 */
 	public function determine_post_template_rules( string $field_group_name, string $param, string $operator, string $value ): void {
 		$templates = $this->get_graphql_post_template_types();
@@ -512,41 +494,6 @@ class LocationRules {
 	 * @param string $param            The parameter of the rule
 	 * @param string $operator         The operator of the rule
 	 * @param string $value            The value of the rule
-	 *
-	 * @return void
-	 */
-	public function determine_post_status_rules( string $field_group_name, string $param, string $operator, string $value ): void {
-		// @todo: Should post status affect the GraphQL Schema at all?
-		// If a field group is set to show on "post_status == publish" as the only rule, what post type does that apply to? All? 🤔
-		// If a field group is set to show on "post_status != draft" does that mean the field group should be available on all post types in the Schema by default?
-		// This seems like a very difficult rule to translate to the Schema.
-		// Like, lets say I add a field group called: "Editor Notes" that I want to show for any status that is not "publish". In theory, if that's my only rule, that seems like it should apply to all post types across the board, and show in the Admin in any state of the post, other than publish. 🤔
-
-		// ACF Admin behavior seems to add it to the Admin on all post types, so WPGraphQL
-		// should respect this rule and also add it to all post types. The resolver should
-		// then determine whether to resolve the data or not, based on this rule.
-
-		// If Post Status is used to qualify a field group location,
-		// It will be added to the Schema for any Post Type that is set to show in GraphQL
-		$allowed_post_types = get_post_types( [ 'show_in_graphql' => true ] );
-		foreach ( $allowed_post_types as $post_type ) {
-			$post_type_object = get_post_type_object( $post_type );
-			$graphql_name     = $post_type_object->graphql_single_name ?? null;
-			if ( ! empty( $graphql_name ) ) {
-				$this->set_graphql_type( $field_group_name, $graphql_name );
-			}
-		}
-	}
-
-	/**
-	 * Determines how the ACF Rules should apply to the WPGraphQL Schema
-	 *
-	 * @param string $field_group_name The name of the ACF Field Group the rule applies to
-	 * @param string $param            The parameter of the rule
-	 * @param string $operator         The operator of the rule
-	 * @param string $value            The value of the rule
-	 *
-	 * @return void
 	 */
 	public function determine_post_format_rules( string $field_group_name, string $param, string $operator, string $value ): void {
 		$post_format_taxonomy   = get_taxonomy( 'post_format' );
@@ -578,25 +525,6 @@ class LocationRules {
 	 * @param string $param            The parameter of the rule
 	 * @param string $operator         The operator of the rule
 	 * @param string $value            The value of the rule
-	 *
-	 * @return void
-	 */
-	public function determine_post_taxonomy_rules( string $field_group_name, string $param, string $operator, string $value ): void {
-
-		// If Post Taxonomy is used to qualify a field group location,
-		// It will be added to the Schema for the Post post type
-		$this->set_graphql_type( $field_group_name, 'Post' );
-	}
-
-	/**
-	 * Determines how the ACF Rules should apply to the WPGraphQL Schema
-	 *
-	 * @param string $field_group_name The name of the ACF Field Group the rule applies to
-	 * @param string $param            The parameter of the rule
-	 * @param string $operator         The operator of the rule
-	 * @param string $value            The value of the rule
-	 *
-	 * @return void
 	 */
 	public function determine_post_rules( string $field_group_name, string $param, string $operator, string $value ): void {
 
@@ -604,35 +532,20 @@ class LocationRules {
 		// It will be added to the Schema for the GraphQL Type for the post_type of the Post
 		// it is assigned to
 
-		if ( '==' === $operator ) {
-			if ( absint( $value ) ) {
-				$post = get_post( absint( $value ) );
-				if ( $post instanceof \WP_Post ) {
-					$post_type_object = get_post_type_object( $post->post_type );
-					if ( $post_type_object && true === $post_type_object->show_in_graphql && isset( $post_type_object->graphql_single_name ) ) {
-						$this->set_graphql_type( $field_group_name, $post_type_object->graphql_single_name );
-					}
+		if ( ( '==' === $operator ) && absint( $value ) ) {
+			$post = get_post( absint( $value ) );
+			if ( $post instanceof \WP_Post ) {
+				$post_type_object = get_post_type_object( $post->post_type );
+				if ( $post_type_object && true === $post_type_object->show_in_graphql && isset( $post_type_object->graphql_single_name ) ) {
+					$this->set_graphql_type( $field_group_name, $post_type_object->graphql_single_name );
 				}
 			}
 		}
 
 		// If a single post is used as not equal,
-		// the field group should be added to ALL post types in the Schema
+		// the field group should not be added to any type
 		if ( '!=' === $operator ) {
-			$allowed_post_types = get_post_types( [ 'show_in_graphql' => true ] );
-
-			if ( empty( $allowed_post_types ) ) {
-				return;
-			}
-
-			// loop over and set all post types
-			foreach ( $allowed_post_types as $allowed_post_type ) {
-				$post_type_object = get_post_type_object( $allowed_post_type );
-				$graphql_name     = $post_type_object->graphql_single_name ?? null;
-				if ( ! empty( $graphql_name ) ) {
-					$this->set_graphql_type( $field_group_name, $graphql_name );
-				}
-			}
+			return;
 		}
 	}
 
@@ -643,8 +556,6 @@ class LocationRules {
 	 * @param string $param            The parameter of the rule
 	 * @param string $operator         The operator of the rule
 	 * @param string $value            The value of the rule
-	 *
-	 * @return void
 	 */
 	public function determine_page_type_rules( string $field_group_name, string $param, string $operator, string $value ): void {
 
@@ -653,30 +564,6 @@ class LocationRules {
 		if ( in_array( $value, [ 'front_page', 'posts_page' ], true ) ) {
 			$this->set_graphql_type( $field_group_name, 'Page' );
 		}
-
-		// If top_level, parent, or child is set as equal_to or not_equal_to
-		// then the field group should be shown on all hierarchical post types
-		if ( in_array( $value, [ 'top_level', 'parent', 'child' ], true ) ) {
-			$hierarchical_post_types = get_post_types(
-				[
-					'show_in_graphql' => true,
-					'hierarchical'    => true,
-				]
-			);
-
-			if ( empty( $hierarchical_post_types ) ) {
-				return;
-			}
-
-			// loop over and set all post types
-			foreach ( $hierarchical_post_types as $allowed_post_type ) {
-				$post_type_object = get_post_type_object( $allowed_post_type );
-				$graphql_name     = $post_type_object->graphql_single_name ?? null;
-				if ( ! empty( $graphql_name ) ) {
-					$this->set_graphql_type( $field_group_name, $graphql_name );
-				}
-			}
-		}
 	}
 
 	/**
@@ -686,8 +573,6 @@ class LocationRules {
 	 * @param string $param            The parameter of the rule
 	 * @param string $operator         The operator of the rule
 	 * @param string $value            The value of the rule
-	 *
-	 * @return void
 	 */
 	public function determine_taxonomy_rules( string $field_group_name, string $param, string $operator, string $value ): void {
 		$allowed_taxonomies = get_taxonomies( [ 'show_in_graphql' => true ] );
@@ -709,13 +594,11 @@ class LocationRules {
 						$this->set_graphql_type( $field_group_name, $graphql_name );
 					}
 				}
-			} else {
-				if ( in_array( $value, $allowed_taxonomies, true ) ) {
+			} elseif ( in_array( $value, $allowed_taxonomies, true ) ) {
 					$tax_object   = get_taxonomy( $value );
 					$graphql_name = $tax_object->graphql_single_name ?? null;
-					if ( ! empty( $graphql_name ) ) {
-						$this->set_graphql_type( $field_group_name, $graphql_name );
-					}
+				if ( ! empty( $graphql_name ) ) {
+					$this->set_graphql_type( $field_group_name, $graphql_name );
 				}
 			}
 		}
@@ -748,8 +631,6 @@ class LocationRules {
 	 * @param string $param            The parameter of the rule
 	 * @param string $operator         The operator of the rule
 	 * @param string $value            The value of the rule
-	 *
-	 * @return void
 	 */
 	public function determine_attachment_rules( string $field_group_name, string $param, string $operator, string $value ): void {
 		if ( '==' === $operator ) {
@@ -768,8 +649,6 @@ class LocationRules {
 	 * @param string $param            The parameter of the rule
 	 * @param string $operator         The operator of the rule
 	 * @param string $value            The value of the rule
-	 *
-	 * @return void
 	 */
 	public function determine_comment_rules( string $field_group_name, string $param, string $operator, string $value ): void {
 		if ( '==' === $operator ) {
@@ -797,8 +676,6 @@ class LocationRules {
 	 * @param string $param            The parameter of the rule
 	 * @param string $operator         The operator of the rule
 	 * @param string $value            The value of the rule
-	 *
-	 * @return void
 	 */
 	public function determine_nav_menu_rules( string $field_group_name, string $param, string $operator, string $value ): void {
 		if ( '==' === $operator ) {
@@ -826,8 +703,6 @@ class LocationRules {
 	 * @param string $param            The parameter of the rule
 	 * @param string $operator         The operator of the rule
 	 * @param string $value            The value of the rule
-	 *
-	 * @return void
 	 */
 	public function determine_nav_menu_item_item_rules( string $field_group_name, string $param, string $operator, string $value ): void {
 		if ( '==' === $operator ) {
@@ -855,8 +730,6 @@ class LocationRules {
 	 * @param string $param            The parameter of the rule
 	 * @param string $operator         The operator of the rule
 	 * @param string $value            The value of the rule
-	 *
-	 * @return void
 	 */
 	public function determine_block_rules( string $field_group_name, string $param, string $operator, string $value ): void {
 		if ( ! function_exists( 'acf_get_block_types' ) ) {
@@ -890,7 +763,7 @@ class LocationRules {
 			}
 
 			$acf_block = acf_get_block_type( $value );
-			if ( ! isset( $acf_block['show_in_graphql'] ) || false === $acf_block['show_in_graphql'] ) {
+			if ( ! isset( $acf_block['show_in_graphql'] ) || false === (bool) $acf_block['show_in_graphql'] ) {
 				return;
 			}
 			$type_name = isset( $acf_block['graphql_field_name'] ) ? Utils::format_type_name( $acf_block['graphql_field_name'] ) : Utils::format_type_name( $acf_block['name'] );
@@ -905,8 +778,6 @@ class LocationRules {
 	 * @param string $param            The parameter of the rule
 	 * @param string $operator         The operator of the rule
 	 * @param string $value            The value of the rule
-	 *
-	 * @return void
 	 */
 	public function determine_options_rules( string $field_group_name, string $param, string $operator, string $value ): void {
 		$options_pages = \WPGraphQL\Acf\Utils::get_acf_options_pages();
@@ -945,7 +816,7 @@ class LocationRules {
 
 			// Get the options page to unset
 			$options_page = acf_get_options_page( $value );
-			if ( ! isset( $options_page['show_in_graphql'] ) || false === $options_page['show_in_graphql'] ) {
+			if ( ! isset( $options_page['show_in_graphql'] ) || false === (bool) $options_page['show_in_graphql'] ) {
 				return;
 			}
 			if ( ! empty( $options_page['graphql_single_name'] ) ) {
@@ -956,5 +827,4 @@ class LocationRules {
 			$this->unset_graphql_type( $field_group_name, $type_name );
 		}
 	}
-
 }

--- a/src/LocationRules/LocationRules.php
+++ b/src/LocationRules/LocationRules.php
@@ -266,12 +266,6 @@ class LocationRules {
 			case 'page_template':
 				$this->determine_post_template_rules( $field_group_name, $param, $operator, $value );
 				break;
-			case 'post_status':
-				break;
-			case 'post_format':
-			case 'post_category':
-			case 'post_taxonomy':
-				break;
 			case 'post':
 				$this->determine_post_rules( $field_group_name, $param, $operator, $value );
 				break;
@@ -283,15 +277,6 @@ class LocationRules {
 				// If page or page_parent is set, regardless of operator and value,
 				// we can add the field group to the Page type
 				$this->set_graphql_type( $field_group_name, 'Page' );
-				break;
-			case 'current_user':
-			case 'current_user_role':
-				// @todo:
-				// Right now, if you set current_user or current_user_role as the only rule,
-				// ACF adds the field group to every possible location in the Admin.
-				// This seems a bit heavy handed. 🤔
-				// We need to think through this a bit more, and how this rule
-				// Can be composed with other rules, etc.
 				break;
 			case 'user_form':
 			case 'user_role':
@@ -307,9 +292,6 @@ class LocationRules {
 				break;
 			case 'comment':
 				$this->determine_comment_rules( $field_group_name, $param, $operator, $value );
-				break;
-			case 'widget':
-				// @todo: Widgets are not currently supported in WPGraphQL
 				break;
 			case 'block':
 				$this->determine_block_rules( $field_group_name, $param, $operator, $value );

--- a/src/Model/AcfOptionsPage.php
+++ b/src/Model/AcfOptionsPage.php
@@ -15,14 +15,14 @@ use WPGraphQL\Model\Model;
  * @property string $capability
  * @property string $acfId
  *
- * @package WPGraphQL\Model
+ * @package WPGraphQL\ACF
  */
 class AcfOptionsPage extends Model {
 
 	/**
 	 * AcfOptionsPage constructor.
 	 *
-	 * @param array $options_page The incoming ACF Options Page to be modeled
+	 * @param array<mixed> $options_page The incoming ACF Options Page to be modeled
 	 *
 	 * @throws \Exception Throws Exception.
 	 */
@@ -32,14 +32,14 @@ class AcfOptionsPage extends Model {
 	}
 
 	/**
-	 * @return array
+	 * @return array<mixed>
 	 */
 	public function get_data(): array {
 		return $this->data;
 	}
 
 	/**
-	 * @return void
+	 * Initialize support for ACF Options Pages loading as a GraphQL Model
 	 */
 	protected function init(): void {
 		if ( empty( $this->fields ) ) {

--- a/src/ThirdParty.php
+++ b/src/ThirdParty.php
@@ -4,7 +4,7 @@ namespace WPGraphQL\Acf;
 class ThirdParty {
 
 	/**
-	 * @return void
+	 * Initialize support for 3rd party libraries / plugins
 	 */
 	public function init(): void {
 
@@ -20,5 +20,4 @@ class ThirdParty {
 		$content_blocks = new ThirdParty\WPGraphQLContentBlocks\WPGraphQLContentBlocks();
 		$content_blocks->init();
 	}
-
 }

--- a/src/ThirdParty/AcfExtended/AcfExtended.php
+++ b/src/ThirdParty/AcfExtended/AcfExtended.php
@@ -21,8 +21,6 @@ class AcfExtended {
 
 	/**
 	 * Initialize support for ACF Extended
-	 *
-	 * @return void
 	 */
 	public function init(): void {
 
@@ -39,8 +37,6 @@ class AcfExtended {
 
 	/**
 	 * Whether ACF Extended is active
-	 *
-	 * @return bool
 	 */
 	public static function is_acfe_active(): bool {
 		$is_active = class_exists( 'ACFE' ) || defined( 'TESTS_ACF_EXTENDED_IS_ACTIVE' );
@@ -52,10 +48,8 @@ class AcfExtended {
 	/**
 	 * Prevent ACF Extended's "dynamic form" and "dynamic form side" field groups from being mapped to the WPGraphQL Schema as they cause infinite recursion.
 	 *
-	 * @param bool $should
-	 * @param array $acf_field_group
-	 *
-	 * @return bool
+	 * @param bool         $should
+	 * @param array<mixed> $acf_field_group
 	 */
 	public function filter_out_acfe_dynamic_groups( bool $should, array $acf_field_group ): bool {
 		if ( ! empty( $acf_field_group['key'] ) && in_array( $acf_field_group['key'], [ 'group_acfe_dynamic_form', 'group_acfe_dynamic_form_side' ], true ) ) {
@@ -68,7 +62,6 @@ class AcfExtended {
 	/**
 	 * Register initial types for ACF Extended field types to use
 	 *
-	 * @return void
 	 * @throws \Exception
 	 */
 	public function register_initial_types(): void {
@@ -384,7 +377,7 @@ class AcfExtended {
 	}
 
 	/**
-	 * @return void
+	 * Register Field Types suppored by the plugin
 	 */
 	public function register_field_types(): void {
 
@@ -392,35 +385,35 @@ class AcfExtended {
 		// - acfe_button
 		// - acfe_hidden
 		// - acfe_recaptcha (not supported. see: https://www.acf-extended.com/features/fields/recaptcha)
-		//   "The value cannot be retrieved, as the field isn’t saved as custom meta"
+		// "The value cannot be retrieved, as the field isn’t saved as custom meta"
 		// - acfe_post_statuses
-		//   @todo: There seems to be general bugs with Post Statuses in core WPGraphQL Still
+		// @todo: There seems to be general bugs with Post Statuses in core WPGraphQL Still
 		// - acfe_block_types
-		//   @todo
+		// @todo
 		// - acfe_field_groups
-		//   @todo
+		// @todo
 		// - acfe_field_types
-		//   @todo
+		// @todo
 		// - acfe_fields
-		//   @todo
+		// @todo
 		// - acfe_forms
-		//   @todo
+		// @todo
 		// - acfe_options_pages
-		//   @todo
+		// @todo
 		// - acfe_templates
-		//   @todo
+		// @todo
 		// - acfe_payment
-		//   @todo
+		// @todo
 		// - acfe_payment_cart
-		//   Not supported: ACFE Docs state: The value cannot be retrieved as the field isn’t saved as meta data.
+		// Not supported: ACFE Docs state: The value cannot be retrieved as the field isn’t saved as meta data.
 		// - acfe_payment_selector
-		//   NOT supported: ACFE Docs state: The value cannot be retrieved as the field isn’t saved as meta data.
+		// NOT supported: ACFE Docs state: The value cannot be retrieved as the field isn’t saved as meta data.
 		// - acfe_column
-		//   Not supported. ACFE docs state: The value cannot be retrieved as the field isn’t saved as meta data.
+		// Not supported. ACFE docs state: The value cannot be retrieved as the field isn’t saved as meta data.
 		// - acfe_dynamic_render
-		//   Not supported. ACFE docs state: "The value cannot be retrieved as the field isn’t saved as meta data."
+		// Not supported. ACFE docs state: "The value cannot be retrieved as the field isn’t saved as meta data."
 		// - acfe_post_field
-		//   Not supported. ACFE docs state: "The value cannot be retrieved as the field isn’t saved as meta data. Values are saved directly within the WP Post Object instead."
+		// Not supported. ACFE docs state: "The value cannot be retrieved as the field isn’t saved as meta data. Values are saved directly within the WP Post Object instead."
 
 
 		// Supported Fields
@@ -441,5 +434,4 @@ class AcfExtended {
 		AcfeTaxonomies::register_field_type();
 		AcfeUserRoles::register_field_type();
 	}
-
 }

--- a/src/ThirdParty/AcfExtended/FieldType/AcfeAdvancedLink.php
+++ b/src/ThirdParty/AcfExtended/FieldType/AcfeAdvancedLink.php
@@ -5,7 +5,7 @@ namespace WPGraphQL\Acf\ThirdParty\AcfExtended\FieldType;
 class AcfeAdvancedLink {
 
 	/**
-	 * @return void
+	 * Register support for the ACF Extended acfe_advanced_link field type
 	 */
 	public static function register_field_type(): void {
 		register_graphql_acf_field_type(
@@ -15,5 +15,4 @@ class AcfeAdvancedLink {
 			]
 		);
 	}
-
 }

--- a/src/ThirdParty/AcfExtended/FieldType/AcfeCodeEditor.php
+++ b/src/ThirdParty/AcfExtended/FieldType/AcfeCodeEditor.php
@@ -5,10 +5,9 @@ namespace WPGraphQL\Acf\ThirdParty\AcfExtended\FieldType;
 class AcfeCodeEditor {
 
 	/**
-	 * @return void
+	 * Register support for the ACF Extended acfe_code_editor field type
 	 */
 	public static function register_field_type(): void {
 		register_graphql_acf_field_type( 'acfe_code_editor' );
 	}
-
 }

--- a/src/ThirdParty/AcfExtended/FieldType/AcfeCountries.php
+++ b/src/ThirdParty/AcfExtended/FieldType/AcfeCountries.php
@@ -5,9 +5,9 @@ namespace WPGraphQL\Acf\ThirdParty\AcfExtended\FieldType;
 class AcfeCountries {
 
 	/**
-	 * @param array|string $countries
+	 * @param array<mixed>|string $countries
 	 *
-	 * @return array|null
+	 * @return array<mixed>|null
 	 */
 	public static function resolve_countries( $countries ): ?array {
 		if ( empty( $countries ) ) {
@@ -27,13 +27,13 @@ class AcfeCountries {
 				static function ( $country ) {
 					return acfe_get_country( $country );
 				},
-				$countries 
-			) 
+				$countries
+			)
 		);
 	}
 
 	/**
-	 * @return void
+	 * Register support for the ACF Extended acfe_countries field type
 	 */
 	public static function register_field_type(): void {
 		register_graphql_acf_field_type(
@@ -50,5 +50,4 @@ class AcfeCountries {
 			]
 		);
 	}
-
 }

--- a/src/ThirdParty/AcfExtended/FieldType/AcfeCurrencies.php
+++ b/src/ThirdParty/AcfExtended/FieldType/AcfeCurrencies.php
@@ -5,9 +5,9 @@ namespace WPGraphQL\Acf\ThirdParty\AcfExtended\FieldType;
 class AcfeCurrencies {
 
 	/**
-	 * @param string|array $currencies
+	 * @param string|array<mixed> $currencies
 	 *
-	 * @return array|null
+	 * @return array<mixed>|null
 	 */
 	public static function resolve_currencies( $currencies ): ?array {
 		if ( empty( $currencies ) ) {
@@ -27,13 +27,13 @@ class AcfeCurrencies {
 				static function ( $currency ) {
 					return acfe_get_currency( $currency );
 				},
-				$currencies 
-			) 
+				$currencies
+			)
 		);
 	}
 
 	/**
-	 * @return void
+	 * Register support for the ACF Extended acfe_currencies field type
 	 */
 	public static function register_field_type(): void {
 		register_graphql_acf_field_type(
@@ -50,5 +50,4 @@ class AcfeCurrencies {
 			]
 		);
 	}
-
 }

--- a/src/ThirdParty/AcfExtended/FieldType/AcfeDateRangePicker.php
+++ b/src/ThirdParty/AcfExtended/FieldType/AcfeDateRangePicker.php
@@ -7,7 +7,7 @@ use WPGraphQL\Acf\FieldConfig;
 class AcfeDateRangePicker {
 
 	/**
-	 * @return void
+	 * Register support for the ACF Extended acfe_date_range_picker field type
 	 */
 	public static function register_field_type(): void {
 		register_graphql_acf_field_type(
@@ -44,5 +44,4 @@ class AcfeDateRangePicker {
 			]
 		);
 	}
-
 }

--- a/src/ThirdParty/AcfExtended/FieldType/AcfeImageSelector.php
+++ b/src/ThirdParty/AcfExtended/FieldType/AcfeImageSelector.php
@@ -5,7 +5,7 @@ namespace WPGraphQL\Acf\ThirdParty\AcfExtended\FieldType;
 class AcfeImageSelector {
 
 	/**
-	 * @return void
+	 * Register support for the ACF Extended acfe_image_selector field type
 	 */
 	public static function register_field_type(): void {
 		register_graphql_acf_field_type(
@@ -28,5 +28,4 @@ class AcfeImageSelector {
 			]
 		);
 	}
-
 }

--- a/src/ThirdParty/AcfExtended/FieldType/AcfeImageSizes.php
+++ b/src/ThirdParty/AcfExtended/FieldType/AcfeImageSizes.php
@@ -5,7 +5,7 @@ namespace WPGraphQL\Acf\ThirdParty\AcfExtended\FieldType;
 class AcfeImageSizes {
 
 	/**
-	 * @return void
+	 * Register support for the ACF Extended acfe_image_sizes field type
 	 */
 	public static function register_field_type(): void {
 		register_graphql_acf_field_type(
@@ -28,12 +28,11 @@ class AcfeImageSizes {
 							static function ( $size ) {
 								return acfe_get_registered_image_sizes( $size );
 							},
-							$value 
-						) 
+							$value
+						)
 					);
 				},
-			] 
+			]
 		);
 	}
-
 }

--- a/src/ThirdParty/AcfExtended/FieldType/AcfeLanguages.php
+++ b/src/ThirdParty/AcfExtended/FieldType/AcfeLanguages.php
@@ -5,9 +5,9 @@ namespace WPGraphQL\Acf\ThirdParty\AcfExtended\FieldType;
 class AcfeLanguages {
 
 	/**
-	 * @param array|string $languages The langauge(s) to resolve as objects
+	 * @param array<mixed>|string $languages The langauge(s) to resolve as objects
 	 *
-	 * @return array|null
+	 * @return array<mixed>|null
 	 */
 	public static function resolve_languages( $languages ): ?array {
 		if ( empty( $languages ) ) {
@@ -27,13 +27,13 @@ class AcfeLanguages {
 				static function ( $language ) {
 					return acfe_get_language( $language );
 				},
-				$languages 
-			) 
+				$languages
+			)
 		);
 	}
 
 	/**
-	 * @return void
+	 * Register support for the ACF Extended acfe_languages field type
 	 */
 	public static function register_field_type(): void {
 		register_graphql_acf_field_type(
@@ -47,5 +47,4 @@ class AcfeLanguages {
 			]
 		);
 	}
-
 }

--- a/src/ThirdParty/AcfExtended/FieldType/AcfeMenuLocations.php
+++ b/src/ThirdParty/AcfExtended/FieldType/AcfeMenuLocations.php
@@ -5,7 +5,7 @@ namespace WPGraphQL\Acf\ThirdParty\AcfExtended\FieldType;
 class AcfeMenuLocations {
 
 	/**
-	 * @return void
+	 * Register support for the ACF Extended acfe_menu_locations field type
 	 */
 	public static function register_field_type(): void {
 		register_graphql_acf_field_type(
@@ -25,8 +25,7 @@ class AcfeMenuLocations {
 
 					return $value;
 				},
-			] 
+			]
 		);
 	}
-
 }

--- a/src/ThirdParty/AcfExtended/FieldType/AcfeMenus.php
+++ b/src/ThirdParty/AcfExtended/FieldType/AcfeMenus.php
@@ -7,7 +7,7 @@ use GraphQL\Deferred;
 class AcfeMenus {
 
 	/**
-	 * @return void
+	 * Register support for the ACF Extended acfe_menus field type
 	 */
 	public static function register_field_type(): void {
 		register_graphql_acf_field_type(
@@ -36,14 +36,13 @@ class AcfeMenus {
 										}
 										return $context->get_loader( 'term' )->load( $nav_menu->term_id );
 									},
-									$value 
-								) 
+									$value
+								)
 							);
 						}
 					);
 				},
-			] 
+			]
 		);
 	}
-
 }

--- a/src/ThirdParty/AcfExtended/FieldType/AcfePhoneNumber.php
+++ b/src/ThirdParty/AcfExtended/FieldType/AcfePhoneNumber.php
@@ -5,10 +5,9 @@ namespace WPGraphQL\Acf\ThirdParty\AcfExtended\FieldType;
 class AcfePhoneNumber {
 
 	/**
-	 * @return void
+	 * Register support for the ACF Extended acfe_phone_number field type
 	 */
 	public static function register_field_type(): void {
 		register_graphql_acf_field_type( 'acfe_phone_number' );
 	}
-
 }

--- a/src/ThirdParty/AcfExtended/FieldType/AcfePostFormats.php
+++ b/src/ThirdParty/AcfExtended/FieldType/AcfePostFormats.php
@@ -5,7 +5,7 @@ namespace WPGraphQL\Acf\ThirdParty\AcfExtended\FieldType;
 class AcfePostFormats {
 
 	/**
-	 * @return void
+	 * Register support for the ACF Extended acfe_post_formats field type
 	 */
 	public static function register_field_type(): void {
 		register_graphql_acf_field_type(
@@ -25,8 +25,7 @@ class AcfePostFormats {
 
 					return $value;
 				},
-			] 
+			]
 		);
 	}
-
 }

--- a/src/ThirdParty/AcfExtended/FieldType/AcfeTaxonomies.php
+++ b/src/ThirdParty/AcfExtended/FieldType/AcfeTaxonomies.php
@@ -7,7 +7,7 @@ use GraphQL\Deferred;
 class AcfeTaxonomies {
 
 	/**
-	 * @return void
+	 * Register support for the ACF Extended acfe_taxonomies field type
 	 */
 	public static function register_field_type(): void {
 		register_graphql_acf_field_type(
@@ -32,14 +32,13 @@ class AcfeTaxonomies {
 									static function ( $taxonomy_name ) use ( $context ) {
 										return $context->get_loader( 'taxonomy' )->load( $taxonomy_name );
 									},
-									$value 
-								) 
+									$value
+								)
 							);
 						}
 					);
 				},
-			] 
+			]
 		);
 	}
-
 }

--- a/src/ThirdParty/AcfExtended/FieldType/AcfeTaxonomyTerms.php
+++ b/src/ThirdParty/AcfExtended/FieldType/AcfeTaxonomyTerms.php
@@ -7,7 +7,7 @@ use GraphQL\Deferred;
 class AcfeTaxonomyTerms {
 
 	/**
-	 * @return void
+	 * Register support for the ACF Extended acfe_taxonomy_terms field type
 	 */
 	public static function register_field_type(): void {
 		register_graphql_acf_field_type(
@@ -31,8 +31,8 @@ class AcfeTaxonomyTerms {
 									static function ( $id ) use ( $context ) {
 										return $context->get_loader( 'term' )->load( (int) $id );
 									},
-									$value 
-								) 
+									$value
+								)
 							);
 						}
 					);
@@ -40,5 +40,4 @@ class AcfeTaxonomyTerms {
 			]
 		);
 	}
-
 }

--- a/src/ThirdParty/AcfExtended/FieldType/AcfeUserRoles.php
+++ b/src/ThirdParty/AcfExtended/FieldType/AcfeUserRoles.php
@@ -9,7 +9,7 @@ use WPGraphQL\AppContext;
 class AcfeUserRoles {
 
 	/**
-	 * @return void
+	 * Register support for the ACF Extended acfe_user_roles field type
 	 */
 	public static function register_field_type(): void {
 		register_graphql_acf_field_type(
@@ -33,14 +33,13 @@ class AcfeUserRoles {
 									static function ( $user_role ) use ( $context ) {
 										return $context->get_loader( 'user_role' )->load( $user_role );
 									},
-									$value 
-								) 
+									$value
+								)
 							);
 						}
 					);
 				},
-			] 
+			]
 		);
 	}
-
 }

--- a/src/ThirdParty/WPGraphQLContentBlocks/WPGraphQLContentBlocks.php
+++ b/src/ThirdParty/WPGraphQLContentBlocks/WPGraphQLContentBlocks.php
@@ -8,8 +8,6 @@ class WPGraphQLContentBlocks {
 
 	/**
 	 * Initialize support for WPGraphQL Content Blocks
-	 *
-	 * @return void
 	 */
 	public function init(): void {
 
@@ -35,11 +33,9 @@ class WPGraphQLContentBlocks {
 	 * @param string                   $block_name                             The name of the block Interfaces will be applied to
 	 * @param \WP_Block_Editor_Context $block_editor_context                   The context of the Block Editor
 	 * @param \WP_Post_Type            $post_type                              The Post Type an Interface might be applied to the block for
-	 * @param array                    $all_registered_blocks                  Array of all registered blocks
-	 * @param array|bool               $supported_blocks_for_post_type_context Array of all supported blocks for the context
-	 * @param array                    $block_and_graphql_enabled_post_types   Array of Post Types that have block editor and GraphQL support
-	 *
-	 * @return bool
+	 * @param array<mixed>             $all_registered_blocks                  Array of all registered blocks
+	 * @param array<mixed>|bool        $supported_blocks_for_post_type_context Array of all supported blocks for the context
+	 * @param array<mixed>             $block_and_graphql_enabled_post_types   Array of Post Types that have block editor and GraphQL support
 	 */
 	public function filter_editor_block_interfaces( bool $should, string $block_name, \WP_Block_Editor_Context $block_editor_context, \WP_Post_Type $post_type, array $all_registered_blocks, $supported_blocks_for_post_type_context, array $block_and_graphql_enabled_post_types ): bool {
 		if ( ! empty( $all_registered_blocks[ $block_name ]->post_types ) && ! in_array( $post_type->name, $all_registered_blocks[ $block_name ]->post_types, true ) ) {
@@ -49,9 +45,9 @@ class WPGraphQLContentBlocks {
 	}
 
 	/**
-	 * @param array $interfaces The interfaces shown as possible types for ACF Field Groups to be associated with
+	 * @param array<mixed> $interfaces The interfaces shown as possible types for ACF Field Groups to be associated with
 	 *
-	 * @return array
+	 * @return array<mixed>
 	 */
 	public function add_blocks_as_possible_type( array $interfaces ): array {
 		$interfaces['AcfBlock'] = [
@@ -67,7 +63,6 @@ class WPGraphQLContentBlocks {
 	 *
 	 * @param \WPGraphQL\Acf\Registry $registry The WPGraphQL for ACF Registry
 	 *
-	 * @return void
 	 * @throws \Exception
 	 */
 	public function register_types( Registry $registry ): void {
@@ -117,6 +112,4 @@ class WPGraphQLContentBlocks {
 
 		register_graphql_interfaces_to_types( [ 'AcfBlock' ], $graphql_enabled_acf_blocks );
 	}
-
-
 }

--- a/src/ThirdParty/WPGraphQLSmartCache/WPGraphQLSmartCache.php
+++ b/src/ThirdParty/WPGraphQLSmartCache/WPGraphQLSmartCache.php
@@ -12,9 +12,9 @@ class WPGraphQLSmartCache {
 	protected $invalidation;
 
 	/**
-	 * @return void
+	 * Initialize support for WPGraphQL Smart Cache
 	 */
-	public function init():void {
+	public function init(): void {
 
 		/**
 		 * Add support for WPGraphQL Smart Cache invalidation for ACF Option Pages
@@ -26,8 +26,8 @@ class WPGraphQLSmartCache {
 	 * @param \WPGraphQL\SmartCache\Cache\Invalidation $invalidation
 	 *
 	 * @return void
+	 * @phpstan-ignore-next-line
 	 */
-	// @phpstan-ignore-next-line
 	public function initialize_cache_invalidation( \WPGraphQL\SmartCache\Cache\Invalidation $invalidation ) {
 			$this->invalidation = $invalidation;
 
@@ -38,10 +38,8 @@ class WPGraphQLSmartCache {
 	 * Purge Cache after ACF Option Page is updated
 	 *
 	 * @param string $option The name of the option being updated
-	 * @param mixed $value The value of the option being updated
-	 * @param mixed $original_value The original / previous value of the option
-	 *
-	 * @return void
+	 * @param mixed  $value The value of the option being updated
+	 * @param mixed  $original_value The original / previous value of the option
 	 */
 	public function updated_acf_option_cb( string $option, $value, $original_value ): void {
 		// phpcs:ignore
@@ -61,5 +59,4 @@ class WPGraphQLSmartCache {
 		// @phpstan-ignore-next-line
 		$this->invalidation->purge( $id, sprintf( 'update_acf_options_page ( "%s" )', $options_page ) );
 	}
-
 }

--- a/src/Utils.php
+++ b/src/Utils.php
@@ -1,18 +1,18 @@
 <?php
 namespace WPGraphQL\Acf;
 
+use WPGraphQL\Acf\Model\AcfOptionsPage;
 use WPGraphQL\Model\Comment;
 use WPGraphQL\Model\Menu;
 use WPGraphQL\Model\MenuItem;
 use WPGraphQL\Model\Post;
 use WPGraphQL\Model\Term;
 use WPGraphQL\Model\User;
-use WPGraphQL\Acf\Model\AcfOptionsPage;
 
 class Utils {
 
 	/**
-	 * @var null|\WPGraphQL\Acf\FieldTypeRegistry
+	 * @var \WPGraphQL\Acf\FieldTypeRegistry|null
 	 */
 	protected static $type_registry;
 
@@ -72,8 +72,6 @@ class Utils {
 
 	/**
 	 * Clear the Type Registry for tests
-	 *
-	 * @return void
 	 */
 	public static function clear_field_type_registry(): void {
 		self::$type_registry = null;
@@ -81,8 +79,6 @@ class Utils {
 
 	/**
 	 * Return the Field Type Registry instance
-	 *
-	 * @return \WPGraphQL\Acf\FieldTypeRegistry
 	 */
 	public static function get_type_registry(): FieldTypeRegistry {
 		if ( self::$type_registry instanceof FieldTypeRegistry ) {
@@ -97,8 +93,6 @@ class Utils {
 	 * Given the name of an ACF Field Type (text, textarea, etc) return the AcfGraphQLFieldType definition
 	 *
 	 * @param string $acf_field_type The name of the ACF Field Type (text, textarea, etc)
-	 *
-	 * @return \WPGraphQL\Acf\AcfGraphQLFieldType|null
 	 */
 	public static function get_graphql_field_type( string $acf_field_type ): ?AcfGraphQLFieldType {
 		return self::get_type_registry()->get_field_type( $acf_field_type );
@@ -112,7 +106,7 @@ class Utils {
 	 *
 	 * Some fields, such as "Accordion" are not supported currently.
 	 *
-	 * @return array
+	 * @return array<mixed>
 	 */
 	public static function get_supported_acf_fields_types(): array {
 		$registry               = self::get_type_registry();
@@ -130,7 +124,7 @@ class Utils {
 	/**
 	 * Returns an array of ACF Options Pages that are set to show in the graphql schema
 	 *
-	 * @return array [<array>]
+	 * @return array<mixed>
 	 */
 	public static function get_acf_options_pages(): array {
 		$options_pages = [];
@@ -156,7 +150,7 @@ class Utils {
 	/**
 	 * Returns all available GraphQL Types
 	 *
-	 * @return array
+	 * @return array<mixed>
 	 * @throws \Exception
 	 */
 	public static function get_all_graphql_types(): array {
@@ -258,9 +252,7 @@ class Utils {
 	/**
 	 * Whether the ACF Field Group should show in the GraphQL Schema
 	 *
-	 * @param array $acf_field
-	 *
-	 * @return bool
+	 * @param array<mixed> $acf_field
 	 */
 	public static function should_field_show_in_graphql( array $acf_field ): bool {
 		return self::should_field_group_show_in_graphql( $acf_field );
@@ -269,9 +261,7 @@ class Utils {
 	/**
 	 * Whether the ACF Field Group should show in the GraphQL Schema
 	 *
-	 * @param array $acf_field_group
-	 *
-	 * @return bool
+	 * @param array<mixed> $acf_field_group
 	 */
 	public static function should_field_group_show_in_graphql( array $acf_field_group ): bool {
 		$should = true;
@@ -284,10 +274,10 @@ class Utils {
 		if (
 			( isset( $acf_field_group['is_options_page'] ) && false === $acf_field_group['is_options_page'] ) &&
 			! isset( $acf_field_group['show_in_graphql'] ) ) {
-			$acf_field_group['show_in_graphql'] = $show_in_rest ?? false;
+			$acf_field_group['show_in_graphql'] = $show_in_rest;
 		}
 
-		if ( isset( $acf_field_group['show_in_graphql'] ) && false === $acf_field_group['show_in_graphql'] ) {
+		if ( isset( $acf_field_group['show_in_graphql'] ) && false === (bool) $acf_field_group['show_in_graphql'] ) {
 			$should = false;
 		}
 
@@ -299,9 +289,7 @@ class Utils {
 	 * Given a field group config, return the name of the field group to be used in the GraphQL
 	 * Schema
 	 *
-	 * @param array $field_group The field group config array
-	 *
-	 * @return string
+	 * @param array<mixed> $field_group The field group config array
 	 */
 	public static function get_field_group_name( array $field_group ): string {
 		$field_group_name = '';
@@ -348,17 +336,15 @@ class Utils {
 	/**
 	 * Returns string of the items in the array list. Limit allows string to be limited length.
 	 *
-	 * @param array $list
-	 * @param int $limit
-	 *
-	 * @return string
+	 * @param array<mixed> $items
+	 * @param int          $limit
 	 */
-	public static function array_list_by_limit( array $list, int $limit = 5 ): string {
+	public static function array_list_by_limit( array $items, int $limit = 5 ): string {
 		$flat_list = '';
-		$total     = count( $list );
+		$total     = count( $items );
 
 		// Labels.
-		$labels     = $list;
+		$labels     = $items;
 		$labels     = array_slice( $labels, 0, $limit );
 		$flat_list .= implode( ', ', $labels );
 
@@ -368,5 +354,4 @@ class Utils {
 		}
 		return $flat_list;
 	}
-
 }

--- a/src/WPGraphQLAcf.php
+++ b/src/WPGraphQLAcf.php
@@ -1,13 +1,12 @@
 <?php
 
 use GraphQL\Type\Definition\ResolveInfo;
-use WPGraphQL\Registry\TypeRegistry;
-
+use WPGraphQL\Acf\Admin\OptionsPageRegistration;
 use WPGraphQL\Acf\Admin\PostTypeRegistration;
 use WPGraphQL\Acf\Admin\TaxonomyRegistration;
-use WPGraphQL\Acf\Admin\OptionsPageRegistration;
 use WPGraphQL\Acf\Registry;
 use WPGraphQL\Acf\ThirdParty;
+use WPGraphQL\Registry\TypeRegistry;
 
 class WPGraphQLAcf {
 
@@ -17,12 +16,18 @@ class WPGraphQLAcf {
 	protected $admin_settings;
 
 	/**
-	 * @var array
+	 * @var array<mixed>
 	 */
 	protected $plugin_load_error_messages = [];
 
 	/**
+	 * @var \WPGraphQL\Acf\Registry|null
+	 */
+	protected $registry;
+
+	/**
 	 * @return void
+	 * Initialize the plugin
 	 */
 	public function init(): void {
 
@@ -39,6 +44,8 @@ class WPGraphQLAcf {
 		add_action( 'after_setup_theme', [ $this, 'acf_internal_post_type_support' ] );
 		add_action( 'graphql_register_types', [ $this, 'init_registry' ] );
 
+		add_filter( 'graphql_resolve_revision_meta_from_parent', [ $this, 'preview_support' ], 10, 4 );
+
 		add_filter( 'graphql_data_loaders', [ $this, 'register_loaders' ], 10, 2 );
 		add_filter( 'graphql_resolve_node_type', [ $this, 'resolve_acf_options_page_node' ], 10, 2 );
 		/**
@@ -51,7 +58,7 @@ class WPGraphQLAcf {
 	}
 
 	/**
-	 * @return void
+	 * Initialize third party support (i.e. Smart Cache, ACF Extended)
 	 */
 	public function init_third_party_support(): void {
 		$third_party = new ThirdParty();
@@ -59,7 +66,7 @@ class WPGraphQLAcf {
 	}
 
 	/**
-	 * @return void
+	 * Initialize support for Admin Settings
 	 */
 	public function init_admin_settings(): void {
 		$this->admin_settings = new WPGraphQL\Acf\Admin\Settings();
@@ -69,8 +76,6 @@ class WPGraphQLAcf {
 	/**
 	 * Add functionality to the Custom Post Type and Custom Taxonomy registration screens
 	 * and underlying functionality (like exports, php code generation)
-	 *
-	 * @return void
 	 */
 	public function acf_internal_post_type_support(): void {
 		$taxonomy_registration_screen = new TaxonomyRegistration();
@@ -86,32 +91,111 @@ class WPGraphQLAcf {
 	/**
 	 * @param \WPGraphQL\Registry\TypeRegistry $type_registry
 	 *
-	 * @return void
 	 * @throws \Exception
 	 */
 	public function init_registry( TypeRegistry $type_registry ): void {
 
 		// Register general types that should be available to the Schema regardless
 		// of the specific fields and field groups registered by ACF
-		$registry = new Registry( $type_registry );
-		$registry->register_initial_graphql_types();
-		$registry->register_options_pages();
+		$this->registry = new Registry( $type_registry );
+		$this->registry->register_initial_graphql_types();
+		$this->registry->register_options_pages();
 
 		// Get the field groups that should be mapped to the Schema
-		$acf_field_groups = $registry->get_acf_field_groups();
+		$acf_field_groups = $this->registry->get_acf_field_groups();
 
 		// If there are no acf field groups to show in GraphQL, do nothing
 		if ( empty( $acf_field_groups ) ) {
 			return;
 		}
 
-		$registry->register_acf_field_groups_to_graphql( $acf_field_groups );
+		$this->registry->register_acf_field_groups_to_graphql( $acf_field_groups );
+	}
+
+	/**
+	 * @param int $post_id The ID of the post to check if it's a preview of another post
+	 *
+	 * @return bool|\WP_Post
+	 */
+	protected function is_preview_post( int $post_id ) {
+		$post = get_post( $post_id );
+
+		if ( ! $post ) {
+			return false; // Post does not exist
+		}
+
+		// Check if it's a revision (autosave)
+		if ( 'revision' === $post->post_type && 'inherit' === $post->post_status ) {
+			$parent_post = get_post( $post->post_parent );
+
+			// Check if parent post is either a draft or published
+			if ( $parent_post && in_array( $parent_post->post_status, [ 'draft', 'publish' ], true ) ) {
+				return $parent_post; // It's a preview of a draft or published post
+			}
+		}
+
+		return false; // Not a preview post
+	}
+
+
+	/**
+	 * Add support for resolving ACF Fields when queried for asPreview
+	 *
+	 * NOTE: this currently only works if classic editor is not being used
+	 *
+	 * @param bool   $should Whether to resolve using the parent object. Default true.
+	 * @param int    $object_id The ID of the object to resolve meta for
+	 * @param string $meta_key The key for the meta to resolve
+	 * @param bool   $single Whether a single value should be returned
+	 */
+	public function preview_support( bool $should, int $object_id, string $meta_key, bool $single ): bool {
+		if ( ! $this->registry instanceof Registry ) {
+			return (bool) $should;
+		}
+
+		$preview_post = $this->is_preview_post( $object_id );
+		if ( ! $preview_post instanceof WP_Post ) {
+			return (bool) $should;
+		}
+
+		// If the block editor is being used for the post, bail early as the Block Editor doesn't
+		// properly support revisions of post meta
+		// see: https://github.com/WordPress/gutenberg/issues/16006#issuecomment-657965028
+		if ( use_block_editor_for_post( $preview_post ) ) {
+			graphql_debug( __( 'The post you are querying as a preview uses the Block Editor and saving & previewing meta is not fully supported by the block editor. This is a WordPress block editor bug. See: https://github.com/WordPress/gutenberg/issues/16006#issuecomment-657965028', 'wpgraphql-acf' ) );
+			return (bool) $should;
+		}
+
+		$registered_fields = $this->registry->get_registered_fields();
+
+		if ( in_array( $meta_key, $registered_fields, true ) ) {
+			return false;
+		}
+
+		foreach ( $registered_fields as $field_name ) {
+			// For flex fields/repeaters, the meta keys are structured a bit funky.
+			// This checks to see if the $meta_key starts with the same string as one of the
+			// acf fields (a flex/repeater field) and then checks if it's preceeded by an underscore and a number.
+			if ( strpos( $meta_key, $field_name ) === 0 ) {
+				// match any string that starts with the field name, followed by an underscore, followed by a number, followed by another string
+				// ex my_flex_field_0_text_field or some_repeater_field_12_25MostPopularDogToys
+				$pattern = '/' . $field_name . '_\d+_\w+/m';
+				preg_match( $pattern, $meta_key, $matches );
+
+				// If the meta key matches the pattern, treat it as a sub-field of an ACF Field Group
+				if ( null !== $matches ) {
+					return false;
+				}
+			}
+		}
+
+		return $should;
 	}
 
 	/**
 	 * Empty array if the plugin can load. Array of messages if the plugin cannot load.
 	 *
-	 * @return array
+	 * @return array<mixed>
 	 */
 	public function get_plugin_load_error_messages(): array {
 		if ( ! empty( $this->plugin_load_error_messages ) ) {
@@ -139,8 +223,6 @@ class WPGraphQLAcf {
 	/**
 	 * Show admin notice to admins if this plugin is active but either ACF and/or WPGraphQL
 	 * are not active
-	 *
-	 * @return void
 	 */
 	public function show_admin_notice(): void {
 		$can_load_messages = $this->get_plugin_load_error_messages();
@@ -188,10 +270,10 @@ class WPGraphQLAcf {
 	}
 
 	/**
-	 * @param array                 $loaders
+	 * @param array<mixed>          $loaders
 	 * @param \WPGraphQL\AppContext $context
 	 *
-	 * @return array
+	 * @return array<mixed>
 	 */
 	public function register_loaders( array $loaders, \WPGraphQL\AppContext $context ): array {
 		$loaders['acf_options_page'] = new \WPGraphQL\Acf\Data\Loader\AcfOptionsPageLoader( $context );
@@ -201,8 +283,6 @@ class WPGraphQLAcf {
 
 	/**
 	 * Output graphql debug messages if the plugin cannot load properly.
-	 *
-	 * @return void
 	 */
 	public function show_graphql_debug_messages(): void {
 		$messages = $this->get_plugin_load_error_messages();
@@ -221,15 +301,15 @@ class WPGraphQLAcf {
 		 * Add the $source node as the "node" passed to the resolver so ACF Fields assigned to Templates can resolve
 		 * using the $source node as the object to get meta from.
 		 *
-		 * @param mixed           $result         The result of the field resolution
-		 * @param mixed           $source         The source passed down the Resolve Tree
-		 * @param array           $args           The args for the field
-		 * @param \WPGraphQL\AppContext $context The AppContext passed down the ResolveTree
-		 * @param \GraphQL\Type\Definition\ResolveInfo $info The ResolveInfo passed down the ResolveTree
-		 * @param string          $type_name      The name of the type the fields belong to
-		 * @param string          $field_key      The name of the field
+		 * @param mixed                                    $result         The result of the field resolution
+		 * @param mixed                                    $source         The source passed down the Resolve Tree
+		 * @param array<mixed>                             $args           The args for the field
+		 * @param \WPGraphQL\AppContext                    $context The AppContext passed down the ResolveTree
+		 * @param \GraphQL\Type\Definition\ResolveInfo     $info The ResolveInfo passed down the ResolveTree
+		 * @param string                                   $type_name      The name of the type the fields belong to
+		 * @param string                                   $field_key      The name of the field
 		 * @param \GraphQL\Type\Definition\FieldDefinition $field The Field Definition for the resolving field
-		 * @param mixed           $field_resolver The default field resolver
+		 * @param mixed                                    $field_resolver The default field resolver
 		 *
 		 * @return mixed
 		 */
@@ -244,5 +324,4 @@ class WPGraphQLAcf {
 
 		return $result;
 	}
-
 }

--- a/tests/_support/WPUnit/AcfFieldTestCase.php
+++ b/tests/_support/WPUnit/AcfFieldTestCase.php
@@ -551,6 +551,45 @@ abstract class AcfFieldTestCase extends WPGraphQLAcfTestCase {
 
 	}
 
+	public function testFieldDoesNotShowInSchemaIfShowInGraphqlIsZero() {
+
+		$field_key = $this->register_acf_field([
+			'show_in_graphql' => 0
+		]);
+
+		$query = '
+		query GetType( $name: String! ) {
+		  __type( name: $name ) {
+		    name
+		    fields {
+		      name
+		    }
+		  }
+		}
+		';
+
+		$actual = $this->graphql( [
+			'query' => $query,
+			'variables' => [
+				'name' => 'AcfTestGroup',
+			]
+		]);
+
+		codecept_debug( $actual );
+
+		// the query should succeed
+		self::assertQuerySuccessful( $actual, [
+			// the instructions should be used for the description
+			$this->not()->expectedNode( '__type.fields', [
+				'name' => $this->get_formatted_field_name(),
+			]),
+		] );
+
+		// remove the local field
+		acf_remove_local_field( $field_key );
+
+	}
+
 	public function testFieldDoesNotShowInSchemaIfShowInGraphqlIsFalse() {
 
 		$field_key = $this->register_acf_field([

--- a/tests/_support/WPUnit/WPGraphQLAcfTestCase.php
+++ b/tests/_support/WPUnit/WPGraphQLAcfTestCase.php
@@ -294,8 +294,6 @@ class WPGraphQLAcfTestCase extends \Tests\WPGraphQL\TestCase\WPGraphQLTestCase {
 	 * @return string
 	 */
 	public function register_acf_field( array $acf_field = [], array $acf_field_group = [] ): string {
-
-
 		$field_group_key = $this->register_acf_field_group( $acf_field_group );
 
 		$key =  $acf_field['key'] ?? uniqid( 'field_acf_test_',true );

--- a/tests/wpunit/FieldTypes/TaxonomyFieldTest.php
+++ b/tests/wpunit/FieldTypes/TaxonomyFieldTest.php
@@ -1,5 +1,7 @@
 <?php
 
+use WPGraphQL\Utils\Utils;
+
 class TaxonomyFieldTest extends \Tests\WPGraphQL\Acf\WPUnit\AcfFieldTestCase {
 
 	/**
@@ -89,5 +91,207 @@ class TaxonomyFieldTest extends \Tests\WPGraphQL\Acf\WPUnit\AcfFieldTestCase {
 				],
 			]
 		];
+	}
+
+	public function testQueryTaxononomyFieldOnBlock() {
+
+		// if ACF PRO is not active, skip the test
+		if ( ! defined( 'ACF_PRO' ) ) {
+			$this->markTestSkipped( 'ACF Pro is not active so this test will not run.' );
+		}
+
+		// If WPGraphQL Content Blocks couldn't be activated, skip
+		if ( ! defined( 'WPGRAPHQL_CONTENT_BLOCKS_DIR' ) ) {
+			$this->markTestSkipped( 'This test is skipped when WPGraphQL Content Blocks is not active' );
+		}
+
+		acf_register_block_type([
+			'name' => 'block_with_category_field',
+			'title' => 'Block with Category Field',
+			'post_types' => [ 'post' ],
+		]);
+
+		$field_key = $this->register_acf_field([
+			'type' => 'taxonomy',
+			'name' => 'Category Test',
+			'show_in_graphql' => true,
+			'graphql_field_name' => 'category',
+			'required' => 1,
+			'taxonomy' => 'category',
+			'add_term' => 0,
+			'save_terms' => 0,
+			'load_terms' => 0,
+			'return_format' => 'object',
+			'field_type' => 'select',
+			'multiple' => 0,
+			'bidirectonal' => 0,
+			'bidirectional_target' => [],
+		], [
+			'name' => 'Block Taxonomy Test',
+			'graphql_field_name' => 'BlockTaxonomyTest',
+			'location' => [
+				[
+					[
+						'param' => 'block',
+						'operator' => '==',
+						'value' => 'acf/block-with-category-field',
+					]
+				]
+			],
+			'graphql_types' => [ 'AcfBlockWithCategoryField' ],
+		]);
+
+		$query = '
+		query GetType( $name: String! ) {
+		  __type( name: $name ) {
+		    fields {
+		      name
+		    }
+		    interfaces {
+		      name
+		    }
+		  }
+		}
+		';
+
+		$actual = $this->graphql( [
+			'query' => $query,
+			'variables' => [
+				'name' => 'AcfBlockWithCategoryField',
+			]
+		]);
+
+		codecept_debug( [
+			'$actual' => $actual,
+		]);
+
+		// Assert that the AcfBlock is in the Schema
+		// Assert the field group shows on the block as expected
+		self::assertQuerySuccessful( $actual, [
+			$this->expectedNode( '__type.fields', [
+				'name' => Utils::format_field_name( 'blockTaxonomyTest' ),
+			]),
+			$this->expectedNode( '__type.interfaces', [
+				'name' => 'AcfBlock',
+			]),
+			// Should implement the With${FieldGroup} Interface
+			$this->expectedNode( '__type.interfaces', [
+				'name' => 'WithAcfBlockTaxonomyTest',
+			])
+		]);
+
+		$category_id = self::factory()->category->create([
+			'name' => uniqid( 'Test Category', true ),
+		]);
+
+		codecept_debug( [
+			'$field_key' => $field_key,
+			'$category_id' => $category_id,
+		]);
+
+		$content = '
+		<!-- wp:acf/block-with-category-field {"name":"acf/block-with-category-field","data":{"' . $field_key . '":"' . $category_id . '"},"align":"","mode":"edit"} /-->
+		';
+
+		$post_id = self::factory()->post->create([
+			'post_type' => 'post',
+			'post_status' => 'publish',
+			'post_title' => 'Test Block With Taxonomy Field',
+			'post_content' => $content,
+		]);
+
+		$query = '
+		query GetPostWithBlocks( $postId: ID! ){
+		  post(id:$postId idType:DATABASE_ID) {
+		    id
+		    title
+		    ...Blocks
+		  }
+		}
+
+		fragment Blocks on NodeWithEditorBlocks {
+		  editorBlocks {
+		    __typename
+		    ...on AcfBlockWithCategoryField {
+		      blockTaxonomyTest {
+		        category {
+		          nodes {
+		            __typename
+		            databaseId
+		          }
+		        }
+		      }
+		    }
+		  }
+		}
+		';
+
+		$variables = [
+			'postId' => $post_id,
+		];
+
+		$actual = self::graphql([
+			'query'     => $query,
+			'variables' => $variables,
+		]);
+
+		codecept_debug( [
+			'$actual' => $actual,
+		]);
+
+		self::assertQuerySuccessful( $actual, [
+			$this->expectedNode( 'post.editorBlocks', [
+				// Expect a block with the __typename AcfBlockWithCategoryField
+				$this->expectedField('__typename', 'AcfBlockWithCategoryField' ),
+				$this->expectedNode( 'blockTaxonomyTest.category.nodes', [
+					'__typename' => 'Category',
+					'databaseId' => $category_id,
+				], 0 ),
+			], 0 ),
+		]);
+
+		$category_2_id = self::factory()->category->create([
+			'name' => uniqid( 'Test Category 2', true ),
+		]);
+
+		$content = '
+		<!-- wp:acf/block-with-category-field {"name":"acf/block-with-category-field","data":{"' . $field_key . '":[' . $category_id . ', ' . $category_2_id . ']},"align":"","mode":"edit"} /-->
+		';
+
+		$post_id = self::factory()->post->create([
+			'post_type' => 'post',
+			'post_status' => 'publish',
+			'post_title' => 'Test Block With Taxonomy Field',
+			'post_content' => $content,
+		]);
+
+		$actual = self::graphql([
+			'query'     => $query,
+			'variables' => $variables,
+		]);
+
+		codecept_debug( [
+			'$actual' => $actual,
+		]);
+
+		self::assertQuerySuccessful( $actual, [
+			$this->expectedNode( 'post.editorBlocks', [
+				// Expect a block with the __typename AcfBlockWithCategoryField
+				$this->expectedField('__typename', 'AcfBlockWithCategoryField' ),
+				$this->expectedNode( 'blockTaxonomyTest.category.nodes', [
+					'__typename' => 'Category',
+					'databaseId' => $category_id,
+				], 0 ),
+//              Only the first node will be returned because the taxonomy field is set to "multiple: 0" so ACF will only return a single value
+//				$this->expectedNode( 'blockTaxonomyTest.category.nodes', [
+//					'__typename' => 'Category',
+//					'databaseId' => $category_2_id,
+//				], 1 ),
+			], 0 ),
+		]);
+
+		wp_delete_post( $post_id );
+		wp_delete_term( $category_id, 'category' );
+		wp_delete_term( $category_2_id, 'category' );
 	}
 }

--- a/tests/wpunit/OptionsPageTest.php
+++ b/tests/wpunit/OptionsPageTest.php
@@ -4,6 +4,8 @@ class OptionsPageTest extends \Tests\WPGraphQL\Acf\WPUnit\WPGraphQLAcfTestCase {
 
 	public function setUp():void {
 
+		WPGraphQL::clear_schema();
+
 		if ( ! function_exists( 'acf_add_options_page' ) ) {
 			$this->markTestSkipped( 'ACF Options Pages are not available in this test environment' );
 		}

--- a/wpgraphql-acf.php
+++ b/wpgraphql-acf.php
@@ -11,6 +11,8 @@
  * Tested up to: 6.2
  * License: GPL-3
  * License URI: https://www.gnu.org/licenses/gpl-3.0.html
+ *
+ * @package  WPGraphQL\ACF
  */
 
 // Exit if accessed directly.

--- a/wpgraphql-acf.php
+++ b/wpgraphql-acf.php
@@ -4,7 +4,7 @@
  * Description: WPGraphQL for ACF seamlessly integrates Advanced Custom Fields with WPGraphQL.
  * Author: WPGraphQL, Jason Bahl
  * Author URI: https://www.wpgraphql.com
- * Version: 2.0.0
+ * Version: 2.1.0
  * Text Domain: wpgraphql-acf
  * Requires PHP: 7.3
  * Requires at least: 5.9
@@ -29,7 +29,7 @@ if ( file_exists( __DIR__ . '/vendor/autoload.php' ) ) {
 }
 
 if ( ! defined( 'WPGRAPHQL_FOR_ACF_VERSION' ) ) {
-	define( 'WPGRAPHQL_FOR_ACF_VERSION', '2.0.0' );
+	define( 'WPGRAPHQL_FOR_ACF_VERSION', '2.1.0' );
 }
 
 if ( ! defined( 'WPGRAPHQL_FOR_ACF_VERSION_WPGRAPHQL_REQUIRED_MIN_VERSION' ) ) {


### PR DESCRIPTION
# Release Notes

## Upgrade Notice

While fixing some [performance issues](https://github.com/wp-graphql/wpgraphql-acf/pull/152) we had to adjust the fallback logic for mapping ACF Field Groups to the Schema if they do not have "graphql_types" defined.

ACF Field Groups that did not have "graphql_types" defined AND were assigned to Location Rules based on "post_status", "post_format", "post_category" or "post_taxonomy" _might_ not show in the Schema until their "graphql_types" are explicitly defined.

## New Features

- [#156](https://github.com/wp-graphql/wpgraphql-acf/pull/156): feat: Use published ACF values in resolvers for fields associated with posts that use the block editor, since the Block Editor has a bug preventing meta from being saved for previews. Adds a debug message if ACF fields are queried for with "asPreview" on post(s) that use the block editor.

### Chores / Bugfixes

- [#156](https://github.com/wp-graphql/wpgraphql-acf/pull/156): fix: ACF Fields not resolving when querying "asPreview"
- [#155](https://github.com/wp-graphql/wpgraphql-acf/pull/155): fix: "show_in_graphql" setting not being respected when turned "off"
- [#152](https://github.com/wp-graphql/wpgraphql-acf/pull/152): fix: performance issues with mapping ACF Field Groups to the Schema
- [#148](https://github.com/wp-graphql/wpgraphql-acf/pull/148): fix: bug when querying taxonomy field on blocks
- [#146](https://github.com/wp-graphql/wpgraphql-acf/pull/146): chore: update phpcs to match core WPGraphQL
