### PR TITLE
fix: user field returning all publicly queryable users

### DIFF
--- a/src/FieldType/User.php
+++ b/src/FieldType/User.php
@@ -39,7 +39,7 @@ class User {
 									return null;
 								}
 
-								$values = [];
+								$values = is_array( $value ) ? $value : [];
 								if ( ! is_array( $value ) ) {
 									$values[] = $value;
 								}
@@ -53,6 +53,10 @@ class User {
 									},
 									$values
 								);
+
+								if ( empty( $value ) ) {
+									return null;
+								}
 
 								$resolver = new UserConnectionResolver( $root, $args, $context, $info );
 								return $resolver->set_query_arg( 'include', $value )->set_query_arg( 'orderby', 'include' )->get_connection();

--- a/tests/_support/WPUnit/WPGraphQLAcfTestCase.php
+++ b/tests/_support/WPUnit/WPGraphQLAcfTestCase.php
@@ -123,6 +123,28 @@ class WPGraphQLAcfTestCase extends \Tests\WPGraphQL\TestCase\WPGraphQLTestCase {
 			],
 		]);
 
+		$this->published_post_by_editor = self::factory()->post->create_and_get([
+			'post_type' => 'post',
+			'post_status' => 'publish',
+			'post_author' => $this->editor->ID,
+			'post_title' => 'Test post by editor title',
+			'tax_input' => [
+				'post_tag' => [ $this->tag->term_id ],
+				'category' => [ $this->category->term_id ],
+			],
+		]);
+
+		$this->published_post_by_author = self::factory()->post->create_and_get([
+			'post_type' => 'post',
+			'post_status' => 'publish',
+			'post_author' => $this->author->ID,
+			'post_title' => 'Test post by author title',
+			'tax_input' => [
+				'post_tag' => [ $this->tag->term_id ],
+				'category' => [ $this->category->term_id ],
+			],
+		]);
+
 		$this->published_page = self::factory()->post->create_and_get([
 			'post_type' => 'page',
 			'post_status' => 'publish',

--- a/tests/wpunit/FieldTypes/TextFieldTest.php
+++ b/tests/wpunit/FieldTypes/TextFieldTest.php
@@ -57,8 +57,19 @@ class TextFieldTest extends \Tests\WPGraphQL\Acf\WPUnit\AcfFieldTestCase {
 		';
 	}
 
-	public function get_block_data_to_store() {
+	public function get_block_data_to_store(): string {
 		return 'text value...';
+	}
+
+	public function get_query_fragment(): string {
+		return '
+		fragment AcfTestGroupFragment on AcfTestGroup {
+		  testText
+		}';
+	}
+
+	public function get_expected_value() {
+		return $this->get_data_to_store();
 	}
 
 	public function get_expected_block_fragment_response() {

--- a/tests/wpunit/FieldTypes/UserFieldTest.php
+++ b/tests/wpunit/FieldTypes/UserFieldTest.php
@@ -28,8 +28,8 @@ class UserFieldTest extends \Tests\WPGraphQL\Acf\WPUnit\AcfFieldTestCase {
 		return 'OBJECT';
 	}
 
-	public function get_data_to_store():string {
-		return $this->admin->ID;
+	public function get_data_to_store() {
+		return [ $this->admin->ID ];
 	}
 
 	public function get_block_query_fragment() {
@@ -55,6 +55,29 @@ class UserFieldTest extends \Tests\WPGraphQL\Acf\WPUnit\AcfFieldTestCase {
 				[
 					'__typename' => 'User',
 					'databaseId' => $this->admin->ID
+				]
+			]
+		];
+	}
+
+	public function get_query_fragment(): string {
+		return '
+		fragment AcfTestGroupFragment on AcfTestGroup {
+		  testUser {
+		    nodes {
+		      __typename
+		      databaseId
+		    }
+		  }
+		}';
+	}
+
+	public function get_expected_value() {
+		return [
+			'nodes' => [
+				[
+					'__typename' => 'User',
+					'databaseId' => $this->admin->ID,
 				]
 			]
 		];


### PR DESCRIPTION
What does this implement/fix? Explain your changes.
---------------------------------------------------
Fixes a bug where the "user" field would return all public users when an array of IDs were stored as the meta value.

- [x] Failing Test: https://github.com/wp-graphql/wpgraphql-acf/actions/runs/7790352471/job/21244045545
- [x] Passing Test: https://github.com/wp-graphql/wpgraphql-acf/actions/runs/7790359717/job/21244045545

Does this close any currently open issues?
------------------------------------------
closes #162 


Any other comments?
-------------------
When saving specific users in a user field: 

![CleanShot 2024-02-05 at 13 15 34](https://github.com/wp-graphql/wpgraphql-acf/assets/1260765/7a4459af-63ed-4c8e-9055-0ffad85249d4)


### BEFORE

Querying would return all publicly queryable users

![CleanShot 2024-02-05 at 13 17 17](https://github.com/wp-graphql/wpgraphql-acf/assets/1260765/7fec4a0c-904c-45b8-bf53-6cdcda0f7419)


### AFTER

Querying returns just the selected users

![CleanShot 2024-02-05 at 13 17 35](https://github.com/wp-graphql/wpgraphql-acf/assets/1260765/59512799-c453-4111-b648-c9e5776302a1)

