### PR TITLE
fix: Taxonomy field returns incorrect data if set to store objects instead of IDs

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -1859,16 +1859,16 @@
         },
         {
             "name": "doctrine/inflector",
-            "version": "2.0.9",
+            "version": "2.0.10",
             "source": {
                 "type": "git",
                 "url": "https://github.com/doctrine/inflector.git",
-                "reference": "2930cd5ef353871c821d5c43ed030d39ac8cfe65"
+                "reference": "5817d0659c5b50c9b950feb9af7b9668e2c436bc"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/doctrine/inflector/zipball/2930cd5ef353871c821d5c43ed030d39ac8cfe65",
-                "reference": "2930cd5ef353871c821d5c43ed030d39ac8cfe65",
+                "url": "https://api.github.com/repos/doctrine/inflector/zipball/5817d0659c5b50c9b950feb9af7b9668e2c436bc",
+                "reference": "5817d0659c5b50c9b950feb9af7b9668e2c436bc",
                 "shasum": ""
             },
             "require": {
@@ -1930,7 +1930,7 @@
             ],
             "support": {
                 "issues": "https://github.com/doctrine/inflector/issues",
-                "source": "https://github.com/doctrine/inflector/tree/2.0.9"
+                "source": "https://github.com/doctrine/inflector/tree/2.0.10"
             },
             "funding": [
                 {
@@ -1946,7 +1946,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2024-01-15T18:05:13+00:00"
+            "time": "2024-02-18T20:23:39+00:00"
         },
         {
             "name": "doctrine/instantiator",
@@ -4096,16 +4096,16 @@
         },
         {
             "name": "phpstan/phpstan",
-            "version": "1.10.58",
+            "version": "1.10.59",
             "source": {
                 "type": "git",
                 "url": "https://github.com/phpstan/phpstan.git",
-                "reference": "a23518379ec4defd9e47cbf81019526861623ec2"
+                "reference": "e607609388d3a6d418a50a49f7940e8086798281"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpstan/phpstan/zipball/a23518379ec4defd9e47cbf81019526861623ec2",
-                "reference": "a23518379ec4defd9e47cbf81019526861623ec2",
+                "url": "https://api.github.com/repos/phpstan/phpstan/zipball/e607609388d3a6d418a50a49f7940e8086798281",
+                "reference": "e607609388d3a6d418a50a49f7940e8086798281",
                 "shasum": ""
             },
             "require": {
@@ -4154,7 +4154,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2024-02-12T20:02:57+00:00"
+            "time": "2024-02-20T13:59:13+00:00"
         },
         {
             "name": "phpunit/php-code-coverage",
@@ -6413,16 +6413,16 @@
         },
         {
             "name": "squizlabs/php_codesniffer",
-            "version": "3.8.1",
+            "version": "3.9.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/PHPCSStandards/PHP_CodeSniffer.git",
-                "reference": "14f5fff1e64118595db5408e946f3a22c75807f7"
+                "reference": "d63cee4890a8afaf86a22e51ad4d97c91dd4579b"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/PHPCSStandards/PHP_CodeSniffer/zipball/14f5fff1e64118595db5408e946f3a22c75807f7",
-                "reference": "14f5fff1e64118595db5408e946f3a22c75807f7",
+                "url": "https://api.github.com/repos/PHPCSStandards/PHP_CodeSniffer/zipball/d63cee4890a8afaf86a22e51ad4d97c91dd4579b",
+                "reference": "d63cee4890a8afaf86a22e51ad4d97c91dd4579b",
                 "shasum": ""
             },
             "require": {
@@ -6489,7 +6489,7 @@
                     "type": "open_collective"
                 }
             ],
-            "time": "2024-01-11T20:47:48+00:00"
+            "time": "2024-02-16T15:06:51+00:00"
         },
         {
             "name": "symfony/browser-kit",

--- a/src/FieldType/Taxonomy.php
+++ b/src/FieldType/Taxonomy.php
@@ -34,7 +34,14 @@ class Taxonomy {
 							}
 
 							$ids = array_map(
-								static function ( $id ) {
+								static function ( $value ) {
+									$id = null;
+									if ( is_array( $value ) ) {
+										$id = $value['term_id'];
+									}
+									if ( isset( $value->term_id ) ) {
+										$id = $value->term_id;
+									}
 									return absint( $id );
 								},
 								$values

--- a/src/FieldType/Taxonomy.php
+++ b/src/FieldType/Taxonomy.php
@@ -33,30 +33,33 @@ class Taxonomy {
 								$values = $value;
 							}
 
-							$ids = array_map(
+							$ids = array_filter( array_map(
 								static function ( $value ) {
-									$id = null;
-									if ( is_array( $value ) ) {
+									$id = $value;
+									if ( is_array( $value ) && isset( $value['term_id'] ) ) {
 										$id = $value['term_id'];
 									}
 									if ( isset( $value->term_id ) ) {
 										$id = $value->term_id;
 									}
-									return absint( $id );
+
+									$id = absint( $id );
+									return ! empty( $id ) ? $id : null;
 								},
 								$values
-							);
+							) );
 
 							if ( empty( $ids ) ) {
 								return null;
 							}
 
 							// set the default ordering if not overridden by args input on the field
-							$args['where']['include'] = $ids;
+							$args['where']['include'] = array_values( $ids );
 							$args['where']['orderby'] = $args['where']['orderby'] ?? 'include';
 							$args['where']['order']   = $args['where']['order'] ?? 'ASC';
-
-							return ( new TermObjectConnectionResolver( $root, $args, $context, $info ) )->get_connection();
+							$args['first']            = count( $ids );
+							$resolver = new TermObjectConnectionResolver( $root, $args, $context, $info, 'any' );
+							return $resolver->get_connection();
 						},
 					];
 

--- a/src/FieldType/Taxonomy.php
+++ b/src/FieldType/Taxonomy.php
@@ -33,21 +33,23 @@ class Taxonomy {
 								$values = $value;
 							}
 
-							$ids = array_filter( array_map(
-								static function ( $value ) {
-									$id = $value;
-									if ( is_array( $value ) && isset( $value['term_id'] ) ) {
-										$id = $value['term_id'];
-									}
-									if ( isset( $value->term_id ) ) {
-										$id = $value->term_id;
-									}
+							$ids = array_filter(
+								array_map(
+									static function ( $value ) {
+										$id = $value;
+										if ( is_array( $value ) && isset( $value['term_id'] ) ) {
+											$id = $value['term_id'];
+										}
+										if ( isset( $value->term_id ) ) {
+											$id = $value->term_id;
+										}
 
-									$id = absint( $id );
-									return ! empty( $id ) ? $id : null;
-								},
-								$values
-							) );
+										$id = absint( $id );
+										return ! empty( $id ) ? $id : null;
+									},
+									$values
+								) 
+							);
 
 							if ( empty( $ids ) ) {
 								return null;
@@ -58,7 +60,7 @@ class Taxonomy {
 							$args['where']['orderby'] = $args['where']['orderby'] ?? 'include';
 							$args['where']['order']   = $args['where']['order'] ?? 'ASC';
 							$args['first']            = count( $ids );
-							$resolver = new TermObjectConnectionResolver( $root, $args, $context, $info, 'any' );
+							$resolver                 = new TermObjectConnectionResolver( $root, $args, $context, $info, 'any' );
 							return $resolver->get_connection();
 						},
 					];

--- a/tests/wpunit/FieldTypes/TaxonomyFieldTest.php
+++ b/tests/wpunit/FieldTypes/TaxonomyFieldTest.php
@@ -393,5 +393,88 @@ class TaxonomyFieldTest extends \Tests\WPGraphQL\Acf\WPUnit\AcfFieldTestCase {
 		wp_delete_term( $category_2_id, 'category' );
 	}
 
+	public function testTaxonomyFieldReturnsExpectedNodeWhenObjectIsSavedInsteadOfId() {
+
+		register_taxonomy( 'test_taxonomy', 'post', [
+			'show_in_graphql' => true,
+			'graphql_single_name' => 'TestCustomTaxonomy',
+			'graphql_plural_name' => 'TestCustomTaxonomies',
+		] );
+
+		$term_object = self::factory()->term->create_and_get( [
+			'taxonomy' => 'test_taxonomy',
+			'name' => 'Test Term',
+		] );
+
+		$field_key = $this->register_acf_field([
+			'type' => 'taxonomy',
+			'name' => 'taxonomy_field_test',
+			'show_in_graphql' => true,
+			'graphql_field_name' => 'testTaxonomyField',
+			'required' => 1,
+			'taxonomy' => 'category',
+			'add_term' => 0,
+			'save_terms' => 0,
+			'load_terms' => 0,
+			'return_format' => 'object',
+			'field_type' => 'select',
+			'multiple' => 0,
+			'bidirectonal' => 0,
+			'bidirectional_target' => [],
+		], [
+			'name' => 'Post Taxonomy Test',
+			'graphql_field_name' => 'TaxonomyFieldTest',
+			'location' => [
+				[
+					[
+						'param' => 'post_type',
+						'operator' => '==',
+						'value' => 'post',
+					]
+				]
+			],
+			'graphql_types' => [ 'Post' ],
+		]);
+
+		update_field( $field_key, $term_object->term_id, $this->published_post->ID );
+
+		$query = '
+		query GetPostAndTaxonomyField( $id: ID! ){
+		  post(id:$id idType:DATABASE_ID) {
+		    id
+		    title
+		      taxonomyFieldTest {
+		        testTaxonomyField {
+		          nodes {
+		            __typename
+		            databaseId
+		          }
+		        }
+		      }
+           }
+        }';
+
+		$variables = [
+			'id' => $this->published_post->ID,
+		];
+
+		$actual = $this->graphql([
+			'query'     => $query,
+			'variables' => $variables,
+		]);
+
+		self::assertQuerySuccessful( $actual, [
+			$this->expectedNode( 'post.taxonomyFieldTest.testTaxonomyField.nodes', [
+				'__typename' => 'TestCustomTaxonomy',
+				'databaseId' => $term_object->term_id,
+			], 0 ),
+		]);
+
+		// cleanup
+		unregister_taxonomy( 'test_taxonomy' );
+		wp_delete_term( $term_object->term_id, 'test_taxonomy' );
+
+	}
+
 
 }

--- a/tests/wpunit/FieldTypes/TaxonomyFieldTest.php
+++ b/tests/wpunit/FieldTypes/TaxonomyFieldTest.php
@@ -471,8 +471,8 @@ class TaxonomyFieldTest extends \Tests\WPGraphQL\Acf\WPUnit\AcfFieldTestCase {
 		]);
 
 		// cleanup
-		unregister_taxonomy( 'test_taxonomy' );
 		wp_delete_term( $term_object->term_id, 'test_taxonomy' );
+		unregister_taxonomy( 'test_taxonomy' );
 
 	}
 


### PR DESCRIPTION
What does this implement/fix? Explain your changes.
---------------------------------------------------

When an ACF Field of the "Taxonomy" type field is set to store objects instead of IDs:

![CleanShot 2024-02-20 at 09 45 36](https://github.com/wp-graphql/wpgraphql-acf/assets/1260765/a80b7172-12c4-4470-a229-8832bc625696)

The resolver returns incorrect information. This resolves that by accounting for IDs or Objects being stored and returned.

Does this close any currently open issues?
------------------------------------------
closes #177 

Any other comments?
-------------------
(see issue #177 for the scenario)

With the following term saved in the "rubrique" field:

![CleanShot 2024-02-20 at 09 46 54](https://github.com/wp-graphql/wpgraphql-acf/assets/1260765/c026be35-4884-4649-928a-31ebacda886c)

## Before:

The "Uncategorized" term is resolved (not expected behavior)

![CleanShot 2024-02-20 at 09 48 03](https://github.com/wp-graphql/wpgraphql-acf/assets/1260765/f987c7aa-15ed-41a6-b0e5-456578087f52)

## After:  

The expected term is resolved:

![CleanShot 2024-02-20 at 09 47 07](https://github.com/wp-graphql/wpgraphql-acf/assets/1260765/d03b38f8-02d0-49ab-9487-48ee49924508)
