### PR TITLE
feat: update docs Date fields to link to the RFC3339 spec 

### DIFF
--- a/src/FieldConfig.php
+++ b/src/FieldConfig.php
@@ -135,6 +135,9 @@ class FieldConfig {
 	 */
 	public function get_field_description(): string {
 
+		$graphql_field_type = $this->get_graphql_field_type();
+		$field_type_config = ( $graphql_field_type instanceof AcfGraphQLFieldType ) ? $graphql_field_type->get_config() : [];
+
 		// Use the explicit graphql_description, if set
 		if ( ! empty( $this->acf_field['graphql_description'] ) ) {
 			$description = $this->acf_field['graphql_description'];
@@ -151,6 +154,15 @@ class FieldConfig {
 				$this->acf_field['type'] ?? '',
 				$this->registry->get_field_group_graphql_type_name( $this->acf_field_group )
 			);
+		}
+
+		if ( isset( $field_type_config['graphql_description_after'] ) ) {
+
+			if ( is_callable( $field_type_config['graphql_description_after'] ) ) {
+				$description .= ' ' . call_user_func( $field_type_config['graphql_description_after'], $this );
+			} else {
+				$description .= ' ' . $field_type_config['graphql_description_after'];
+			}
 		}
 
 		return $description;

--- a/src/FieldConfig.php
+++ b/src/FieldConfig.php
@@ -136,7 +136,7 @@ class FieldConfig {
 	public function get_field_description(): string {
 
 		$graphql_field_type = $this->get_graphql_field_type();
-		$field_type_config = ( $graphql_field_type instanceof AcfGraphQLFieldType ) ? $graphql_field_type->get_config() : [];
+		$field_type_config  = ( $graphql_field_type instanceof AcfGraphQLFieldType ) ? $graphql_field_type->get_config() : [];
 
 		// Use the explicit graphql_description, if set
 		if ( ! empty( $this->acf_field['graphql_description'] ) ) {
@@ -157,7 +157,6 @@ class FieldConfig {
 		}
 
 		if ( isset( $field_type_config['graphql_description_after'] ) ) {
-
 			if ( is_callable( $field_type_config['graphql_description_after'] ) ) {
 				$description .= ' ' . call_user_func( $field_type_config['graphql_description_after'], $this );
 			} else {

--- a/src/FieldType/DatePicker.php
+++ b/src/FieldType/DatePicker.php
@@ -18,7 +18,7 @@ class DatePicker {
 				'graphql_description_after'  => function( FieldConfig $field_config ) {
 					$field_type = $field_config->get_acf_field()['type'] ?? null;
 
-					return '(' . sprintf( __( 'ACF Fields of the %s type return a date string in the format `YYYYMMDD` according to the RFC3339 spec: https://datatracker.ietf.org/doc/html/rfc3339.', 'wp-graphql-acf' ), $field_type ) . ')';
+					return '(' . sprintf( __( 'ACF Fields of the %s type return a date string according to the RFC3339 spec: https://datatracker.ietf.org/doc/html/rfc3339.', 'wp-graphql-acf' ), $field_type ) . ')';
 				},
 				'resolve'      => static function ( $root, $args, $context, $info, $field_type, FieldConfig $field_config ) {
 					$value = $field_config->resolve_field( $root, $args, $context, $info );

--- a/src/FieldType/DatePicker.php
+++ b/src/FieldType/DatePicker.php
@@ -13,6 +13,13 @@ class DatePicker {
 			'date_picker',
 			[
 				'graphql_type' => 'String',
+				// Apply a description to be appended to the field description.
+				// @todo: consider removing when CustomScalar types are supported along with the @specifiedBy directive
+				'graphql_description_after'  => function( FieldConfig $field_config ) {
+					$field_type = $field_config->get_acf_field()['type'] ?? null;
+
+					return '(' . sprintf( __( 'ACF Fields of the %s type return a date string in the format `YYYYMMDD` according to the RFC3339 spec: https://datatracker.ietf.org/doc/html/rfc3339.', 'wp-graphql-acf' ), $field_type ) . ')';
+				},
 				'resolve'      => static function ( $root, $args, $context, $info, $field_type, FieldConfig $field_config ) {
 					$value = $field_config->resolve_field( $root, $args, $context, $info );
 

--- a/src/FieldType/DatePicker.php
+++ b/src/FieldType/DatePicker.php
@@ -12,15 +12,16 @@ class DatePicker {
 		register_graphql_acf_field_type(
 			'date_picker',
 			[
-				'graphql_type' => 'String',
+				'graphql_type'              => 'String',
 				// Apply a description to be appended to the field description.
 				// @todo: consider removing when CustomScalar types are supported along with the @specifiedBy directive
-				'graphql_description_after'  => function( FieldConfig $field_config ) {
+				'graphql_description_after' => static function ( FieldConfig $field_config ) {
 					$field_type = $field_config->get_acf_field()['type'] ?? null;
 
-					return '(' . sprintf( __( 'ACF Fields of the %s type return a date string according to the RFC3339 spec: https://datatracker.ietf.org/doc/html/rfc3339.', 'wp-graphql-acf' ), $field_type ) . ')';
+					// translators: The $s is the name of the acf field type that is returning a date string according to the RFC3339 spec.
+					return '(' . sprintf( __( 'ACF Fields of the %s type return a date string according to the RFC3339 spec: https://datatracker.ietf.org/doc/html/rfc3339.', 'wpgraphql-acf' ), $field_type ) . ')';
 				},
-				'resolve'      => static function ( $root, $args, $context, $info, $field_type, FieldConfig $field_config ) {
+				'resolve'                   => static function ( $root, $args, $context, $info, $field_type, FieldConfig $field_config ) {
 					$value = $field_config->resolve_field( $root, $args, $context, $info );
 
 					if ( empty( $value ) ) {

--- a/src/FieldType/DateTimePicker.php
+++ b/src/FieldType/DateTimePicker.php
@@ -14,6 +14,13 @@ class DateTimePicker {
 			'date_time_picker',
 			[
 				'graphql_type' => 'String',
+				// Apply a description to be appended to the field description.
+				// @todo: consider removing when CustomScalar types are supported along with the @specifiedBy directive
+				'graphql_description_after'  => function( FieldConfig $field_config ) {
+					$field_type = $field_config->get_acf_field()['type'] ?? null;
+
+					return '(' . sprintf( __( 'ACF Fields of the %s type return a date string in the format `YYYYMMDD` according to the RFC3339 spec: https://datatracker.ietf.org/doc/html/rfc3339.', 'wp-graphql-acf' ), $field_type ) . ')';
+				},
 				'resolve'      => static function ( $root, $args, $context, $info, $field_type, FieldConfig $field_config ) {
 					$value = $field_config->resolve_field( $root, $args, $context, $info );
 

--- a/src/FieldType/DateTimePicker.php
+++ b/src/FieldType/DateTimePicker.php
@@ -13,15 +13,16 @@ class DateTimePicker {
 		register_graphql_acf_field_type(
 			'date_time_picker',
 			[
-				'graphql_type' => 'String',
+				'graphql_type'              => 'String',
 				// Apply a description to be appended to the field description.
 				// @todo: consider removing when CustomScalar types are supported along with the @specifiedBy directive
-				'graphql_description_after'  => function( FieldConfig $field_config ) {
+				'graphql_description_after' => static function ( FieldConfig $field_config ) {
 					$field_type = $field_config->get_acf_field()['type'] ?? null;
 
-					return '(' . sprintf( __( 'ACF Fields of the %s type return a date string according to the RFC3339 spec: https://datatracker.ietf.org/doc/html/rfc3339.', 'wp-graphql-acf' ), $field_type ) . ')';
+					// translators: The $s is the name of the acf field type that is returning a date string according to the RFC3339 spec.
+					return '(' . sprintf( __( 'ACF Fields of the "%s" type return a date string according to the RFC3339 spec: https://datatracker.ietf.org/doc/html/rfc3339.', 'wpgraphql-acf' ), $field_type ) . ')';
 				},
-				'resolve'      => static function ( $root, $args, $context, $info, $field_type, FieldConfig $field_config ) {
+				'resolve'                   => static function ( $root, $args, $context, $info, $field_type, FieldConfig $field_config ) {
 					$value = $field_config->resolve_field( $root, $args, $context, $info );
 
 					if ( empty( $value ) ) {

--- a/src/FieldType/DateTimePicker.php
+++ b/src/FieldType/DateTimePicker.php
@@ -19,7 +19,7 @@ class DateTimePicker {
 				'graphql_description_after'  => function( FieldConfig $field_config ) {
 					$field_type = $field_config->get_acf_field()['type'] ?? null;
 
-					return '(' . sprintf( __( 'ACF Fields of the %s type return a date string in the format `YYYYMMDD` according to the RFC3339 spec: https://datatracker.ietf.org/doc/html/rfc3339.', 'wp-graphql-acf' ), $field_type ) . ')';
+					return '(' . sprintf( __( 'ACF Fields of the %s type return a date string according to the RFC3339 spec: https://datatracker.ietf.org/doc/html/rfc3339.', 'wp-graphql-acf' ), $field_type ) . ')';
 				},
 				'resolve'      => static function ( $root, $args, $context, $info, $field_type, FieldConfig $field_config ) {
 					$value = $field_config->resolve_field( $root, $args, $context, $info );

--- a/src/FieldType/FlexibleContent.php
+++ b/src/FieldType/FlexibleContent.php
@@ -73,7 +73,9 @@ class FlexibleContent {
 								)
 							);
 
-							$layout['sub_fields'] = array_merge( $sub_fields, $layout['sub_fields'] );
+							$layout_sub_fields = ! empty( $layout['sub_fields'] ) && is_array( $layout['sub_fields'] ) ? $layout['sub_fields'] : [];
+
+							$layout['sub_fields'] = array_merge( $sub_fields, $layout_sub_fields );
 
 							$layouts[] = $layout;
 						}

--- a/src/ThirdParty/AcfExtended/AcfExtended.php
+++ b/src/ThirdParty/AcfExtended/AcfExtended.php
@@ -339,12 +339,12 @@ class AcfExtended {
 					'startDate' => [
 						// @todo: DATETIME Scalar
 						'type'        => 'String',
-						'description' => __( 'The start date of a date range returned as an RFC 3339 time string', 'wpgraphql-acf' ),
+						'description' => __( 'The start date of a date range returned as an RFC 3339 time string (https://datatracker.ietf.org/doc/html/rfc3339)', 'wpgraphql-acf' ),
 					],
 					'endDate'   => [
 						// @todo: DATETIME Scalar
 						'type'        => 'String',
-						'description' => __( 'The start date of a date range RFC 3339 time string', 'wpgraphql-acf' ),
+						'description' => __( 'The start date of a date range RFC 3339 time string (https://datatracker.ietf.org/doc/html/rfc3339)', 'wpgraphql-acf' ),
 					],
 				],
 			]

--- a/tests/_support/WPUnit/AcfFieldTestCase.php
+++ b/tests/_support/WPUnit/AcfFieldTestCase.php
@@ -672,10 +672,13 @@ abstract class AcfFieldTestCase extends WPGraphQLAcfTestCase {
 			// the instructions should be used for the description
 			// if "graphql_description" is not provided
 			$this->expectedNode( '__type.fields', [
-				'name' => $this->get_formatted_field_name(),
-				'description' => $instructions
+				$this->expectedField( 'name', $this->get_formatted_field_name() ),
+				$this->expectedField( 'description', self::NOT_NULL ),
 			]),
+
 		] );
+
+		$this->assertStringContainsString( $instructions, $actual['data']['__type']['fields'][0]['description'] );
 
 		// remove the local field
 		acf_remove_local_field( $field_key );
@@ -720,10 +723,13 @@ abstract class AcfFieldTestCase extends WPGraphQLAcfTestCase {
 			// the instructions should be used for the description
 			// if "graphql_description" is not provided
 			$this->expectedNode( '__type.fields', [
-				'name' => $this->get_formatted_field_name(),
-				'description' => $graphql_description
+				$this->expectedField( 'name', $this->get_formatted_field_name() ),
+				$this->expectedField( 'description', self::NOT_NULL ),
 			]),
 		] );
+
+		$this->assertStringContainsString( $graphql_description, $actual['data']['__type']['fields'][0]['description'] );
+
 
 		// remove the local field
 		acf_remove_local_field( $field_key );


### PR DESCRIPTION
What does this implement/fix? Explain your changes.
---------------------------------------------------
This updates the GraphQL field descriptions for fields of the DatePicker and DateTimePicker ACF field type to indicate that the strings returned will be formatted in RFC3339 format. 

This is helpful for client developers to know how they can expect to interact with the resulting value. 


Does this close any currently open issues?
------------------------------------------
closes #161 


Any other comments?
-------------------

In the WPGraphQL IDE we can see the field descriptions now include a link to the RFC3339 spec and a description that the field will return according to that spec. 
![CleanShot 2024-02-21 at 15 03 27](https://github.com/wp-graphql/wpgraphql-acf/assets/1260765/f34b77da-bfeb-4ebc-9066-39c09c8a514b)

![CleanShot 2024-02-21 at 14 53 50](https://github.com/wp-graphql/wpgraphql-acf/assets/1260765/45a5f38e-ff90-4648-b7e1-20b59bc64a44)

![CleanShot 2024-02-21 at 15 03 36](https://github.com/wp-graphql/wpgraphql-acf/assets/1260765/c4074b57-9e01-4900-866e-3220723cfb02)
