### PR TITLE
fix: admin_enqueue_scripts callback should expect a possible null value passed to it

### DIFF
--- a/src/Admin/PostTypeRegistration.php
+++ b/src/Admin/PostTypeRegistration.php
@@ -167,10 +167,17 @@ class PostTypeRegistration {
 	}
 
 	/**
-	 * @param string $screen
+	 * Enqueue the admin scripts for the ACF Post Type settings.
+	 * This script is only enqueued on the ACF Post Type edit screen.
+	 *
+	 * @param ?string $screen
 	 */
-	public function enqueue_admin_scripts( string $screen ): void {
+	public function enqueue_admin_scripts( ?string $screen ): void {
 		global $post;
+
+		if ( empty( $screen ) ) {
+			return;
+		}
 
 		// if the screen is not a new post / edit post screen, do nothing
 		if ( ! ( 'post-new.php' === $screen || 'post.php' === $screen ) ) {

--- a/src/Admin/TaxonomyRegistration.php
+++ b/src/Admin/TaxonomyRegistration.php
@@ -165,10 +165,17 @@ class TaxonomyRegistration {
 	}
 
 	/**
-	 * @param string $screen
+	 * Enqueue the admin scripts for the ACF Post Type settings.
+	 * This script is only enqueued on the ACF Taxonomy edit screen.
+	 *
+	 * @param ?string $screen
 	 */
-	public function enqueue_admin_scripts( string $screen ): void {
+	public function enqueue_admin_scripts( ?string $screen ): void {
 		global $post;
+
+		if ( empty( $screen ) ) {
+			return;
+		}
 
 		// if the screen is not a new post / edit post screen, do nothing
 		if ( ! ( 'post-new.php' === $screen || 'post.php' === $screen ) ) {


### PR DESCRIPTION
What does this implement/fix? Explain your changes.
---------------------------------------------------
This updates the enqueue_admin_assets callback to expect a possible null value for the argument passed from `do_action( 'admin_enqueue_scripts' );`


Does this close any currently open issues?
------------------------------------------
closes #180 