### PR TITLE
fix: clone field within a group field type returns null values

### DIFF
--- a/src/FieldConfig.php
+++ b/src/FieldConfig.php
@@ -146,7 +146,7 @@ class FieldConfig {
 			// Fallback description
 			// translators: %s is the name of the ACF Field Group
 			$description = sprintf(
-				// translators: %1$s is the ACF Field Type and %2$s is the name of the ACF Field Group
+			// translators: %1$s is the ACF Field Type and %2$s is the name of the ACF Field Group
 				__( 'Field of the "%1$s" Field Type added to the schema as part of the "%2$s" Field Group', 'wpgraphql-acf' ),
 				$this->acf_field['type'] ?? '',
 				$this->registry->get_field_group_graphql_type_name( $this->acf_field_group )
@@ -390,17 +390,11 @@ class FieldConfig {
 
 		// If the root being passed down already has a value
 		// for the field key, let's use it to resolve
-		if ( isset( $field_config['key'] ) && ! empty( $root[ $field_config['key'] ] ) ) {
-			return $this->prepare_acf_field_value( $root[ $field_config['key'] ], $node, $node_id, $field_config );
+		if ( ! empty( $root[ $field_key ] ) ) {
+			return $this->prepare_acf_field_value( $root[ $field_key ], $node, $node_id, $field_config );
 		}
 
-		// Check if the cloned field key is being used to pass values down
-		if ( isset( $field_config['__key'] ) && ! empty( $root[ $field_config['__key'] ] ) ) {
-			return $this->prepare_acf_field_value( $root[ $field_config['__key'] ], $node, $node_id, $field_config );
-		}
-
-		// Else check if the values are being passed down via the name
-		if ( isset( $field_config['name'] ) && ! empty( $root[ $field_config['name'] ] ) ) {
+		if ( ! empty( $root[ $field_config['name'] ] ) ) {
 			return $this->prepare_acf_field_value( $root[ $field_config['name'] ], $node, $node_id, $field_config );
 		}
 

--- a/src/FieldConfig.php
+++ b/src/FieldConfig.php
@@ -390,11 +390,17 @@ class FieldConfig {
 
 		// If the root being passed down already has a value
 		// for the field key, let's use it to resolve
-		if ( ! empty( $root[ $field_key ] ) ) {
-			return $this->prepare_acf_field_value( $root[ $field_key ], $node, $node_id, $field_config );
+		if ( isset( $field_config['key'] ) && ! empty( $root[ $field_config['key'] ] ) ) {
+			return $this->prepare_acf_field_value( $root[ $field_config['key'] ], $node, $node_id, $field_config );
 		}
 
-		if ( ! empty( $root[ $field_config['name'] ] ) ) {
+		// Check if the cloned field key is being used to pass values down
+		if ( isset( $field_config['__key'] ) && ! empty( $root[ $field_config['__key'] ] ) ) {
+			return $this->prepare_acf_field_value( $root[ $field_config['__key'] ], $node, $node_id, $field_config );
+		}
+
+		// Else check if the values are being passed down via the name
+		if ( isset( $field_config['name'] ) && ! empty( $root[ $field_config['name'] ] ) ) {
 			return $this->prepare_acf_field_value( $root[ $field_config['name'] ], $node, $node_id, $field_config );
 		}
 

--- a/src/FieldConfig.php
+++ b/src/FieldConfig.php
@@ -146,7 +146,7 @@ class FieldConfig {
 			// Fallback description
 			// translators: %s is the name of the ACF Field Group
 			$description = sprintf(
-			// translators: %1$s is the ACF Field Type and %2$s is the name of the ACF Field Group
+				// translators: %1$s is the ACF Field Type and %2$s is the name of the ACF Field Group
 				__( 'Field of the "%1$s" Field Type added to the schema as part of the "%2$s" Field Group', 'wpgraphql-acf' ),
 				$this->acf_field['type'] ?? '',
 				$this->registry->get_field_group_graphql_type_name( $this->acf_field_group )
@@ -390,11 +390,17 @@ class FieldConfig {
 
 		// If the root being passed down already has a value
 		// for the field key, let's use it to resolve
-		if ( ! empty( $root[ $field_key ] ) ) {
-			return $this->prepare_acf_field_value( $root[ $field_key ], $node, $node_id, $field_config );
+		if ( isset( $field_config['key'] ) && ! empty( $root[ $field_config['key'] ] ) ) {
+			return $this->prepare_acf_field_value( $root[ $field_config['key'] ], $node, $node_id, $field_config );
 		}
 
-		if ( ! empty( $root[ $field_config['name'] ] ) ) {
+		// Check if the cloned field key is being used to pass values down
+		if ( isset( $field_config['__key'] ) && ! empty( $root[ $field_config['__key'] ] ) ) {
+			return $this->prepare_acf_field_value( $root[ $field_config['__key'] ], $node, $node_id, $field_config );
+		}
+
+		// Else check if the values are being passed down via the name
+		if ( isset( $field_config['name'] ) && ! empty( $root[ $field_config['name'] ] ) ) {
 			return $this->prepare_acf_field_value( $root[ $field_config['name'] ], $node, $node_id, $field_config );
 		}
 


### PR DESCRIPTION
What does this implement/fix? Explain your changes.
---------------------------------------------------

checks if the value is being passed down with the' __key' or the 'key' to better compensate for clone fields, specifically when groups are cloned

- [x] failing test: https://github.com/wp-graphql/wpgraphql-acf/actions/runs/8164650916
- [x] passing test: https://github.com/wp-graphql/wpgraphql-acf/actions/runs/8164655172

Does this close any currently open issues?
------------------------------------------
fixes #184 
fixes #151 


Any other comments?
-------------------

I believe this addresses the issues reported in #184 and #184 

Below are some before/after examples:

## Issue 184

Following the reported steps to reproduce (see #184): 

### Before

![CleanShot 2024-03-04 at 16 04 35](https://github.com/wp-graphql/wpgraphql-acf/assets/1260765/dfe0d19d-67e0-47d2-bb4a-3ee860d0304b)

### After

![CleanShot 2024-03-04 at 15 50 53](https://github.com/wp-graphql/wpgraphql-acf/assets/1260765/f6d23f3e-65b7-484a-aeae-89469929abda)


## Issue 151

Following the reported steps to reproduce (see #151): 

### Before

![CleanShot 2024-03-04 at 16 10 46](https://github.com/wp-graphql/wpgraphql-acf/assets/1260765/e1cb0e1c-6434-4592-99e4-feacbbeb477f)


### After

![CleanShot 2024-03-04 at 16 09 59](https://github.com/wp-graphql/wpgraphql-acf/assets/1260765/8f72d2e2-4450-4212-b227-815916e42390)


