### PR TITLE
fix: use Discord links

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -7,7 +7,7 @@ body:
         Thank you for taking the time to report a possible bug!
 
         Please remember, a bug report is not the place to ask questions. You can
-        use [Slack](https://join.slack.com/t/wp-graphql/shared_invite/zt-3vloo60z-PpJV2PFIwEathWDOxCTTLA) for that, or start a topic in [GitHub
+        use [Discord](https://www.wpgraphql.com/discord) for that, or start a topic in [GitHub
         Discussions](https://github.com/wp-graphql/wpgraphql-acf/discussions).
   - type: textarea
     attributes:

--- a/README.md
+++ b/README.md
@@ -159,7 +159,7 @@ Yes! You can register ACF Field Groups and Fields using the Admin UI, PHP or JSO
 ## Support
 
 - [General Help Requests](https://github.com/wp-graphql/wp-graphql/discussions): For general questions and help requests, create a new topic in Github Discussions
-- [Slack Community](https://join.slack.com/t/wp-graphql/shared_invite/zt-3vloo60z-PpJV2PFIwEathWDOxCTTLA): The WPGraphQL Slack is a great place to communicate in real-time. Ask questions, discuss features, get to know other folks using WPGraphQL.
+- [Discord Community](https://www.wpgraphql.com/discord): The WPGraphQL Discord is a great place to communicate in real-time. Ask questions, discuss features, get to know other folks using WPGraphQL.
 - [Bug Reports](https://github.com/wp-graphql/wp-graphql/issues/new?assignees=&labels=&projects=&template=bug_report.yml): Report a bug in WPGraphQL
 - [Feature Requests](https://github.com/wp-graphql/wp-graphql/issues/new?assignees=&labels=&projects=&template=feature_request.yml): Suggest an idea, feature, or enhancement for WPGraphQL.
 - [Report a Security Vulnerability](https://github.com/wp-graphql/wp-graphql/security/advisories/new): Report a security vulnerability.

--- a/readme.txt
+++ b/readme.txt
@@ -45,7 +45,7 @@ Learn more about Semver at [semver.org](https://semver.org).
 == Support ==
 
 - [General Help Requests](https://github.com/wp-graphql/wp-graphql/discussions): For general questions and help requests, create a new topic in Github Discussions
-- [Slack Community](https://join.slack.com/t/wp-graphql/shared_invite/zt-3vloo60z-PpJV2PFIwEathWDOxCTTLA): The WPGraphQL Slack is a great place to communicate in real-time. Ask questions, discuss features, get to know other folks using WPGraphQL.
+- [Discord Community](https://www.wpgraphql.com/discord): The WPGraphQL Discord is a great place to communicate in real-time. Ask questions, discuss features, get to know other folks using WPGraphQL.
 - [Bug Reports](https://github.com/wp-graphql/wp-graphql/issues/new?assignees=&labels=&projects=&template=bug_report.yml): Report a bug in WPGraphQL
 - [Feature Requests](https://github.com/wp-graphql/wp-graphql/issues/new?assignees=&labels=&projects=&template=feature_request.yml): Suggest an idea, feature, or enhancement for WPGraphQL.
 - [Report a Security Vulnerability](https://github.com/wp-graphql/wp-graphql/security/advisories/new): Report a security vulnerability.


### PR DESCRIPTION
<!--

### Your checklist for this pull request
Thanks for sending a pull request! Please make sure you click the link above to view the contribution guidelines, then fill out the blanks below.

-->

What does this implement/fix? Explain your changes.
---------------------------------------------------
I was looking through the readme and docs to try and learn how to spin up a local development copy to work on a bugfix. While doing so, I noticed some outdated Slack references and thought they could point to the new Discord instead.

I used the WPGraphQL website `/discord` URL instead of the direct Discord invite link because it seemed like the redirect setup makes it more manageable to swap out the invite link later if needed.


Does this close any currently open issues?
------------------------------------------
<!--
### Write "closes #{pr number}"
### see: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->
No.

Any relevant logs, error output, GraphiQL screenshots, etc?
-------------------------------------
(If it’s long, please paste to https://ghostbin.com/ and insert the link here.)
N/A

Any other comments?
-------------------
N/A


Where has this been tested?
---------------------------
Documentation update, no code changes, nothing to test that I'm aware of.
