### PR TITLE
fix field groups with Block Types set to 'All' not showing up in block schema

### DIFF
--- a/src/LocationRules/LocationRules.php
+++ b/src/LocationRules/LocationRules.php
@@ -719,14 +719,22 @@ class LocationRules {
 		}
 
 		if ( '==' === $operator ) {
-			$acf_block = acf_get_block_type( $value );
+			if ( 'all' === $value ) {
+				$acf_blocks = acf_get_block_types();
+				foreach ( $acf_blocks as $acf_block ) {
+					$type_name = \WPGraphQL\Acf\Utils::get_field_group_name( $acf_block );
+					$this->set_graphql_type( $field_group_name, $type_name );
+				}
+			} else {
+				$acf_block = acf_get_block_type( $value );
 
-			if ( empty( $acf_block ) || ! \WPGraphQL\Acf\Utils::should_field_group_show_in_graphql( $acf_block ) ) {
-				return;
+				if ( empty( $acf_block ) || ! \WPGraphQL\Acf\Utils::should_field_group_show_in_graphql( $acf_block ) ) {
+					return;
+				}
+
+				$type_name = \WPGraphQL\Acf\Utils::get_field_group_name( $acf_block );
+				$this->set_graphql_type( $field_group_name, $type_name );
 			}
-
-			$type_name = \WPGraphQL\Acf\Utils::get_field_group_name( $acf_block );
-			$this->set_graphql_type( $field_group_name, $type_name );
 		}
 
 		if ( '!=' === $operator ) {


### PR DESCRIPTION
What does this implement/fix? Explain your changes.
---------------------------------------------------
This fixes a bug where a field group with a Location rule set to All Blocks would not show up in any ACF blocks' GraphQL schema

Does this close any currently open issues?
------------------------------------------
No


Any relevant logs, error output, GraphiQL screenshots, etc?
-------------------------------------
Location rules like this:
<img width="1191" alt="image" src="https://github.com/user-attachments/assets/158bc264-f6fb-465f-8d07-312f2e05dab2" />

Before:
<img width="299" alt="image" src="https://github.com/user-attachments/assets/abae62c3-43c4-4bdd-8ee2-d6cb6a620e33" />

After:

<img width="298" alt="image" src="https://github.com/user-attachments/assets/a8dbd83e-d0c9-4c71-aeab-28c0ac0a1b4d" />
<img width="1160" alt="image" src="https://github.com/user-attachments/assets/9bae1389-43bd-42c7-84e3-c2de04a89e5f" />
