### PR TITLE
chore: deprecated filter

### DIFF
--- a/src/WPGraphQLAcf.php
+++ b/src/WPGraphQLAcf.php
@@ -46,7 +46,7 @@ class WPGraphQLAcf {
 
 		add_filter( 'graphql_resolve_revision_meta_from_parent', [ $this, 'preview_support' ], 10, 4 );
 
-		add_filter( 'graphql_data_loaders', [ $this, 'register_loaders' ], 10, 2 );
+		add_filter( 'graphql_data_loader_classes', [ $this, 'register_loaders' ], 10, 2 );
 		add_filter( 'graphql_resolve_node_type', [ $this, 'resolve_acf_options_page_node' ], 10, 2 );
 		/**
 		 * This filters any field that returns the `ContentTemplate` type


### PR DESCRIPTION
What does this implement/fix? Explain your changes.
---------------------------------------------------
Fix the deprecation warning of `graphql_data_loaders` filter.

Warning:
> _The graphql_data_loaders filter is deprecated and will be removed in a future version. Instead, use the graphql_data_loader_classes filter to add/change data loader classes before they are instantiated.
https://github.com/wp-graphql/wp-graphql/blob/131659f1a6118dcf429480002d979c4016440c20/src/AppContext.php#L196-L209_


Does this close any currently open issues?
------------------------------------------
<!--
### Write "closes #{pr number}"
### see: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->
Did not find any relate issue or PR

Any relevant logs, error output, GraphiQL screenshots, etc?
-------------------------------------
https://pastebin.com/raw/H7pdAPLx


Any other comments?
-------------------
…


Where has this been tested?
---------------------------
https://pastebin.com/raw/6WvCxG3d